### PR TITLE
Ligand Graph Featurizer

### DIFF
--- a/kinoml/features/core.py
+++ b/kinoml/features/core.py
@@ -213,21 +213,25 @@ class BaseOneHotEncodingFeaturizer(BaseFeaturizer):
         raise NotImplementedError
 
     @staticmethod
-    def one_hot_encode(sequence: str, dictionary: dict) -> np.ndarray:
+    def one_hot_encode(sequence: Iterable, dictionary: Union[dict, list]) -> np.ndarray:
         """
         One-hot encode a sequence of characters, given a dictionary
 
         Parameters
         ----------
-        sequence : str
-        dictionary : dict
-            Mapping of each character to their position in the alphabet
+        sequence : Iterable
+        dictionary : dict or list
+            Mapping of each character to their position in the alphabet. If list
+            is given, it will be enumerated into a dict.
 
         Returns
         -------
         array-like
             One-hot encoded matrix with shape ``(len(dictionary), len(sequence))``
         """
+        if not isinstance(dictionary, dict):
+            dictionary = {value: index for (index, value) in enumerate(dictionary)}
+
         ohe_matrix = np.zeros((len(dictionary), len(sequence)))
         for i, character in enumerate(sequence):
             ohe_matrix[dictionary[character], i] = 1

--- a/kinoml/features/ligand.py
+++ b/kinoml/features/ligand.py
@@ -304,8 +304,7 @@ class GraphLigandFeaturizer(SingleLigandFeaturizer):
 
         return connectivity_graph, per_atom_features
 
-    @staticmethod
-    def _per_atom_features(atom, max_in_ring_size: int = 10):
+    def _per_atom_features(self, atom, max_in_ring_size: int = 10):
         """
         Computes desired features for each atom in the molecular graph.
 
@@ -362,50 +361,56 @@ class GraphLigandFeaturizer(SingleLigandFeaturizer):
             if atom.IsInRingSize(ring_size_probe):
                 ring_size = ring_size_probe
 
-        return (
-            # Same properties as the one used in potentialnet
-            # 1. Chemical element, one-hot encoded
-            BaseOneHotEncodingFeaturizer.one_hot_encode([atom.GetAtomicNum()], ALL_ATOMIC_SYMBOLS),
-            # 2. Formal charge
-            atom.GetFormalCharge(),
-            # 3. Hybridization, one-hot encoded
-            BaseOneHotEncodingFeaturizer.one_hot_encode([atom.GetHybridization().real], rdkit.Chem.rdchem.HybridizationType.names),
-            # 4. Aromaticity
-            atom.GetIsAromatic(),
-            # 5. Total numbers of bonds
-            atom.GetDegree(),
-            # 6. Total number of hydrogens
-            atom.GetTotalNumHs(),
-            # 7. Number of implicit hydrogens
-            atom.GetNumImplicitHs(),
-            # 8. Number of radical electrons
-            atom.GetNumRadicalElectrons(),
-
-            ## Others
-            #atom.GetAtomicNum(),
-            #atom.GetSymbol(),  # TODO : one-hot encode
-            #atom.GetDegree(),
-            #atom.GetTotalDegree(),  # TODO : ignore if molecule has H
-            #atom.GetExplicitValence(),
-            #atom.GetImplicitValence(),  # TODO : ignore if molecule has H
-            #atom.GetTotalValence(),
-            #atom.GetMass(),
-            #atom.GetFormalCharge(),
-            #atom.GetNumExplicitHs(),
-            #atom.GetNumImplicitHs(),
-            #atom.GetTotalNumHs(),
-            #atom.IsInRing(),
-            #ring_size,  # TODO : one-hot encode
-            #atom.GetIsAromatic(),
-            #atom.GetNumRadicalElectrons(),
-            ## We use the .real attribute of the hybridization type
-            ## This Enum uses complex numbers to encode the different
-            ## types. `.name` will give you the type string, and `.real`
-            ## will give you the position in the enum object.
-            ## There's a total of 8 possible values. You can check them
-            ## with `rdkit.Chem.rdchem.HybridizationType.names` and/or
-            ## `rdkit.Chem.rdchem.HybridizationType.values`
-            #atom.GetHybridization().real,  # TODO : one-hot encode
+        # TODO: Array should be of the same type; right now it mixes several types
+        return np.array(
+            [
+                # Same properties as the one used in potentialnet
+                # 1. Chemical element, one-hot encoded
+                BaseOneHotEncodingFeaturizer.one_hot_encode(
+                    [atom.GetSymbol()], self.ALL_ATOMIC_SYMBOLS
+                ),
+                # 2. Formal charge
+                atom.GetFormalCharge(),
+                # 3. Hybridization, one-hot encoded
+                BaseOneHotEncodingFeaturizer.one_hot_encode(
+                    [atom.GetHybridization().name], rdkit.Chem.rdchem.HybridizationType.names
+                ),
+                # 4. Aromaticity
+                atom.GetIsAromatic(),
+                # 5. Total numbers of bonds
+                atom.GetDegree(),
+                # 6. Total number of hydrogens
+                atom.GetTotalNumHs(),
+                # 7. Number of implicit hydrogens
+                atom.GetNumImplicitHs(),
+                # 8. Number of radical electrons
+                atom.GetNumRadicalElectrons(),
+                ## Others
+                # atom.GetAtomicNum(),
+                # atom.GetSymbol(),  # TODO : one-hot encode
+                # atom.GetDegree(),
+                # atom.GetTotalDegree(),  # TODO : ignore if molecule has H
+                # atom.GetExplicitValence(),
+                # atom.GetImplicitValence(),  # TODO : ignore if molecule has H
+                # atom.GetTotalValence(),
+                # atom.GetMass(),
+                # atom.GetFormalCharge(),
+                # atom.GetNumExplicitHs(),
+                # atom.GetNumImplicitHs(),
+                # atom.GetTotalNumHs(),
+                # atom.IsInRing(),
+                # ring_size,  # TODO : one-hot encode
+                # atom.GetIsAromatic(),
+                # atom.GetNumRadicalElectrons(),
+                ## We use the .real attribute of the hybridization type
+                ## This Enum uses complex numbers to encode the different
+                ## types. `.name` will give you the type string, and `.real`
+                ## will give you the position in the enum object.
+                ## There's a total of 8 possible values. You can check them
+                ## with `rdkit.Chem.rdchem.HybridizationType.names` and/or
+                ## `rdkit.Chem.rdchem.HybridizationType.values`
+                # atom.GetHybridization().real,  # TODO : one-hot encode
+            ]
         )
 
     @staticmethod

--- a/kinoml/features/ligand.py
+++ b/kinoml/features/ligand.py
@@ -295,12 +295,10 @@ class GraphLigandFeaturizer(SingleLigandFeaturizer):
         """
         ligand = self._find_ligand(system).to_rdkit()
         connectivity_graph = self._connectivity_COO_format(ligand)
-        per_atom_features = np.array(
-            [
-                self._per_atom_features(a, max_in_ring_size=self.max_in_ring_size)
-                for a in ligand.GetAtoms()
-            ]
-        )
+        per_atom_features = [
+            self._per_atom_features(a, max_in_ring_size=self.max_in_ring_size)
+            for a in ligand.GetAtoms()
+        ]
 
         return connectivity_graph, per_atom_features
 
@@ -362,55 +360,53 @@ class GraphLigandFeaturizer(SingleLigandFeaturizer):
                 ring_size = ring_size_probe
 
         # TODO: Array should be of the same type; right now it mixes several types
-        return np.array(
-            [
-                # Same properties as the one used in potentialnet
-                # 1. Chemical element, one-hot encoded
-                BaseOneHotEncodingFeaturizer.one_hot_encode(
-                    [atom.GetSymbol()], self.ALL_ATOMIC_SYMBOLS
-                ),
-                # 2. Formal charge
-                atom.GetFormalCharge(),
-                # 3. Hybridization, one-hot encoded
-                BaseOneHotEncodingFeaturizer.one_hot_encode(
-                    [atom.GetHybridization().name], rdkit.Chem.rdchem.HybridizationType.names
-                ),
-                # 4. Aromaticity
-                atom.GetIsAromatic(),
-                # 5. Total numbers of bonds
-                atom.GetDegree(),
-                # 6. Total number of hydrogens
-                atom.GetTotalNumHs(),
-                # 7. Number of implicit hydrogens
-                atom.GetNumImplicitHs(),
-                # 8. Number of radical electrons
-                atom.GetNumRadicalElectrons(),
-                ## Others
-                # atom.GetAtomicNum(),
-                # atom.GetSymbol(),  # TODO : one-hot encode
-                # atom.GetDegree(),
-                # atom.GetTotalDegree(),  # TODO : ignore if molecule has H
-                # atom.GetExplicitValence(),
-                # atom.GetImplicitValence(),  # TODO : ignore if molecule has H
-                # atom.GetTotalValence(),
-                # atom.GetMass(),
-                # atom.GetFormalCharge(),
-                # atom.GetNumExplicitHs(),
-                # atom.GetNumImplicitHs(),
-                # atom.GetTotalNumHs(),
-                # atom.IsInRing(),
-                # ring_size,  # TODO : one-hot encode
-                # atom.GetIsAromatic(),
-                # atom.GetNumRadicalElectrons(),
-                ## We use the .real attribute of the hybridization type
-                ## This Enum uses complex numbers to encode the different
-                ## types. `.name` will give you the type string, and `.real`
-                ## will give you the position in the enum object.
-                ## There's a total of 8 possible values. You can check them
-                ## with `rdkit.Chem.rdchem.HybridizationType.names` and/or
-                ## `rdkit.Chem.rdchem.HybridizationType.values`
-                # atom.GetHybridization().real,  # TODO : one-hot encode
-            ]
+        return (
+            # Same properties as the one used in potentialnet
+            # 1. Chemical element, one-hot encoded
+            BaseOneHotEncodingFeaturizer.one_hot_encode(
+                [atom.GetSymbol()], self.ALL_ATOMIC_SYMBOLS
+            ),
+            # 2. Formal charge
+            atom.GetFormalCharge(),
+            # 3. Hybridization, one-hot encoded
+            BaseOneHotEncodingFeaturizer.one_hot_encode(
+                [atom.GetHybridization().name], rdkit.Chem.rdchem.HybridizationType.names
+            ),
+            # 4. Aromaticity
+            atom.GetIsAromatic(),
+            # 5. Total numbers of bonds
+            atom.GetDegree(),
+            # 6. Total number of hydrogens
+            atom.GetTotalNumHs(),
+            # 7. Number of implicit hydrogens
+            atom.GetNumImplicitHs(),
+            # 8. Number of radical electrons
+            atom.GetNumRadicalElectrons(),
+            ## Others
+            # atom.GetAtomicNum(),
+            # atom.GetSymbol(),  # TODO : one-hot encode
+            # atom.GetDegree(),
+            # atom.GetTotalDegree(),  # TODO : ignore if molecule has H
+            # atom.GetExplicitValence(),
+            # atom.GetImplicitValence(),  # TODO : ignore if molecule has H
+            # atom.GetTotalValence(),
+            # atom.GetMass(),
+            # atom.GetFormalCharge(),
+            # atom.GetNumExplicitHs(),
+            # atom.GetNumImplicitHs(),
+            # atom.GetTotalNumHs(),
+            # atom.IsInRing(),
+            # ring_size,  # TODO : one-hot encode
+            # atom.GetIsAromatic(),
+            # atom.GetNumRadicalElectrons(),
+            ## We use the .real attribute of the hybridization type
+            ## This Enum uses complex numbers to encode the different
+            ## types. `.name` will give you the type string, and `.real`
+            ## will give you the position in the enum object.
+            ## There's a total of 8 possible values. You can check them
+            ## with `rdkit.Chem.rdchem.HybridizationType.names` and/or
+            ## `rdkit.Chem.rdchem.HybridizationType.values`
+            # atom.GetHybridization().real,  # TODO : one-hot encode
         )
 
     @staticmethod

--- a/kinoml/features/ligand.py
+++ b/kinoml/features/ligand.py
@@ -363,30 +363,49 @@ class GraphLigandFeaturizer(SingleLigandFeaturizer):
                 ring_size = ring_size_probe
 
         return (
-            atom.GetAtomicNum(),
-            atom.GetSymbol(),  # TODO : one-hot encode
-            atom.GetDegree(),
-            atom.GetTotalDegree(),  # TODO : ignore if molecule has H
-            atom.GetExplicitValence(),
-            atom.GetImplicitValence(),  # TODO : ignore if molecule has H
-            atom.GetTotalValence(),
-            atom.GetMass(),
+            # Same properties as the one used in potentialnet
+            # 1. Chemical element, one-hot encoded
+            BaseOneHotEncodingFeaturizer.one_hot_encode([atom.GetAtomicNum()], ALL_ATOMIC_SYMBOLS),
+            # 2. Formal charge
             atom.GetFormalCharge(),
-            atom.GetNumExplicitHs(),
-            atom.GetNumImplicitHs(),
-            atom.GetTotalNumHs(),
-            atom.IsInRing(),
-            ring_size,  # TODO : one-hot encode
+            # 3. Hybridization, one-hot encoded
+            BaseOneHotEncodingFeaturizer.one_hot_encode([atom.GetHybridization().real], rdkit.Chem.rdchem.HybridizationType.names),
+            # 4. Aromaticity
             atom.GetIsAromatic(),
+            # 5. Total numbers of bonds
+            atom.GetDegree(),
+            # 6. Total number of hydrogens
+            atom.GetTotalNumHs(),
+            # 7. Number of implicit hydrogens
+            atom.GetNumImplicitHs(),
+            # 8. Number of radical electrons
             atom.GetNumRadicalElectrons(),
-            # We use the .real attribute of the hybridization type
-            # This Enum uses complex numbers to encode the different
-            # types. `.name` will give you the type string, and `.real`
-            # will give you the position in the enum object.
-            # There's a total of 8 possible values. You can check them
-            # with `rdkit.Chem.rdchem.HybridizationType.names` and/or
-            # `rdkit.Chem.rdchem.HybridizationType.values`
-            atom.GetHybridization().real,  # TODO : one-hot encode
+
+            ## Others
+            #atom.GetAtomicNum(),
+            #atom.GetSymbol(),  # TODO : one-hot encode
+            #atom.GetDegree(),
+            #atom.GetTotalDegree(),  # TODO : ignore if molecule has H
+            #atom.GetExplicitValence(),
+            #atom.GetImplicitValence(),  # TODO : ignore if molecule has H
+            #atom.GetTotalValence(),
+            #atom.GetMass(),
+            #atom.GetFormalCharge(),
+            #atom.GetNumExplicitHs(),
+            #atom.GetNumImplicitHs(),
+            #atom.GetTotalNumHs(),
+            #atom.IsInRing(),
+            #ring_size,  # TODO : one-hot encode
+            #atom.GetIsAromatic(),
+            #atom.GetNumRadicalElectrons(),
+            ## We use the .real attribute of the hybridization type
+            ## This Enum uses complex numbers to encode the different
+            ## types. `.name` will give you the type string, and `.real`
+            ## will give you the position in the enum object.
+            ## There's a total of 8 possible values. You can check them
+            ## with `rdkit.Chem.rdchem.HybridizationType.names` and/or
+            ## `rdkit.Chem.rdchem.HybridizationType.values`
+            #atom.GetHybridization().real,  # TODO : one-hot encode
         )
 
     @staticmethod

--- a/kinoml/tests/features/test_ligand.py
+++ b/kinoml/tests/features/test_ligand.py
@@ -120,7 +120,7 @@ def test_ligand_OneHotSMILESFeaturizer_RDKit(smiles, solution):
             "CC",
             (
                 np.array([[0, 1], [1, 0]]),
-                np.array(
+                (
                     [
                         (6, "C", 1, 4, 1, 3, 4, 12.011, 0, 0, 3, 3, False, 0, False, 0, 4),
                         (6, "C", 1, 4, 1, 3, 4, 12.011, 0, 0, 3, 3, False, 0, False, 0, 4),
@@ -142,4 +142,9 @@ def test_ligand_GraphLigandFeaturizer_RDKit(smiles, solution):
     featurizer.featurize(system)
     graph = system.featurizations[featurizer.name]
     assert (graph[0] == solution[0]).all()  # connectivity
-    assert graph[1] == solution[1]  # features
+    for atom_g, atom_s in zip(graph[1], solution[1]):  # features
+        for feature_g, feature_s in zip(atom_g, atom_s):
+            try:
+                assert feature_g == feature_s
+            except ValueError:
+                assert (feature_g == feature_s).all()

--- a/kinoml/tests/features/test_ligand.py
+++ b/kinoml/tests/features/test_ligand.py
@@ -142,4 +142,4 @@ def test_ligand_GraphLigandFeaturizer_RDKit(smiles, solution):
     featurizer.featurize(system)
     graph = system.featurizations[featurizer.name]
     assert (graph[0] == solution[0]).all()  # connectivity
-    assert (graph[1] == solution[1]).all()  # features
+    assert graph[1] == solution[1]  # features


### PR DESCRIPTION
## Description
Tie up loose ends for the graph ligand featurizer and more specifically, the atomic features.

By default, we will use the same ones as the PotentialNet model, https://doi.org/10.1021/acscentsci.8b00507.

Taken from the PotentialNet paper:

"Deep Neural Networks were constructed and trained with PyTorch.(52) Custom Python code was used based on RDKit(53) and OEChem(54) with frequent use of NumPy(55) and SciPy.(56) Networks were trained on **chemical element, formal charge, hybridization, aromaticity, and the total numbers of bonds, hydrogens (total and implicit), and radical electrons.** "


## Todos
  - [x] Check the atomic features in PotentialNet
  - [x] Implement the same in kinoml
  - [ ] Unit test
  - [ ] Running on `experiments-binding-affinity`

## Questions
- How to one-hot encode based on a list of string? `BaseOneHotEncodingFeaturizer.one_hot_encode([atom.GetHybridization().real], rdkit.Chem.rdchem.HybridizationType.names)`
- Is it the best way to go to one-hot encode most atomic properties? Maybe just use this version of kinoml https://github.com/openkinome/kinoml/blob/1cf6f95b7763c335227133d4d569f92e76d337f7/kinoml/features/ligand.py#L214 
- Should we use all available rdkit atomic properties? In RDKit: atomic properties https://www.rdkit.org/docs/source/rdkit.Chem.rdchem.html#rdkit.Chem.rdchem.Atom

## Status
- [ ] Ready to go

## Notes
For sake of completion, let's look at the features implemented in
1. deepchem (see [code]( https://github.com/deepchem/deepchem/blob/25b9527e1af62797bbd81b1195cfad49d89f1380/deepchem/feat/graph_features.py#L114)) , and used in [MoleculeNet](http://moleculenet.ai/):
- one-hot encoded atomic symbol
- one-hot encoded degree
- one-hot encoded implicit valence
- formal charge
- number of radical electrons
- one-hot encoded hybridization type
- aromaticity
2. Takayuki Serizawa et al., [poster](https://github.com/rdkit/UGM_2019/blob/master/Poster/Serizawa_MolecularPropertyPrediction.pdf) presentation at the RDKit UGM 2019:
- one-hot atom type
- one-hot degree
- one-hot valence
- formal charge
- one-hot hybridization type
- number of racial electrons
- aromaticity
- one-hot encoded number of hydrogen atoms
- partial charge (not rkdit!)