### PR TITLE
minor fix

### DIFF
--- a/kinoml/features/core.py
+++ b/kinoml/features/core.py
@@ -642,7 +642,7 @@ class HashFeaturizer(BaseFeaturizer):
         inputdata = self.getter(system)
 
         h = hashlib.sha256(inputdata.encode(encoding="UTF-8"))
-        return np.array(int(h.hexdigest(), base=16) / self.denominator)
+        return np.reshape(np.array(int(h.hexdigest(), base=16) / self.denominator), -1)
 
 
 class NullFeaturizer(BaseFeaturizer):


### PR DESCRIPTION
## Description
Kinase-informed featurizer. Change shape output for the kinase hash so that the concatenation axis runs as for the kinase composition in the `experiments` repo.

## Todos
  - [x] Change hash numpy shape from () to (1,)

## Questions
- The unit test runs without failing even with this edit? @jaimergp 

## Status
- [x] Ready to go