### PR TITLE
ML training

### DIFF
--- a/kinoml/ml/torch_geometric_models.py
+++ b/kinoml/ml/torch_geometric_models.py
@@ -6,8 +6,18 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch_geometric.nn import GCNConv
 
+class _BaseModule(nn.Module):
+    needs_input_shape = True
 
-class GraphConvolutionNeuralNetwork(nn.Module):
+    @staticmethod
+    def estimate_input_shape(input_sample):
+        # Take the first batch [0]
+        # From (adjacency, per node) tensors, take per node [1]
+        # From per node tensor, take the number of features [1]
+        return input_sample[0][1][1].shape
+
+
+class GraphConvolutionNeuralNetwork(_BaseModule):
     """
     Builds a Graph Convolutional Network and a feed-forward pass
 
@@ -24,15 +34,15 @@ class GraphConvolutionNeuralNetwork(nn.Module):
     """
 
     def __init__(
-        self, nb_nodes_features=9, embedding_shape=100, output_shape=1, activation=F.relu
+        self, input_shape, embedding_shape=100, output_shape=1, activation=F.relu
     ):
         super().__init__()
-        self.nb_nodes_features = nb_nodes_features
+        self.input_shape = input_shape[0] # nb of per node features
         self.embedding_shape = embedding_shape
         self.output_shape = output_shape
         self._activation = activation
 
-        self.GraphConvLayer1 = GCNConv(self.nb_nodes_features, self.embedding_shape)
+        self.GraphConvLayer1 = GCNConv(self.input_shape, self.embedding_shape)
         self.GraphConvLayer2 = GCNConv(self.embedding_shape, self.output_shape)
 
     def forward(self, data):

--- a/kinoml/ml/torch_models.py
+++ b/kinoml/ml/torch_models.py
@@ -165,7 +165,7 @@ class ConvolutionNeuralNetworkRegression(_BaseModule):
         """
         Defines the foward pass for a given input 'x'
         """
-        x = self._activation(self.convolution(x))
+        x = self._activation(self.convolution(x.float()))
         x = torch.flatten(x, 1)
         x = self._activation(self.fully_connected_1(x))
         return self.fully_connected_out(x)
@@ -239,10 +239,13 @@ class ConvolutionNeuralNetworkRegressionKinaseInformed(_BaseModule):
         self.fully_connected_1 = nn.Linear(self.temp_ligand + self.temp_protein, self.hidden_shape)
         self.fully_connected_out = nn.Linear(self.hidden_shape, self.output_shape)
 
-    def forward(self, x_ligand, x_protein):
+    def forward(self, x):
         """
         Defines the foward pass for given two inputs: ligand and protein.
         """
+        x_ligand, x_protein = zip(*x)
+        x_ligand = torch.tensor(x_ligand)
+        x_protein = torch.tensor(x_protein)
         x_lig = self._activation(self.convolution_ligand(x_ligand))
         x_prot = self._activation(self.convolution_protein(x_protein))
 


### PR DESCRIPTION
## Description
Make changes to train machine learning (ML) models in `experiments-binding-affinity` repo.

## Todos
- [ ] estimate input shape for not only vector, but tensor
- [ ] Featurization
    - [ ] Add KLIFS binding site sequence: one-hot encoded
    - [ ] Add KLIFS binding site sequence: composition
- [ ] Unpack x_train (a list) into x_ligang and x_protein for CNN of ohe smiles and ohe sequence
- [ ] Unpack x_train (a list) into connectivity and per_atom_features for graph nn. 
- [ ] Add padding in the featurization for one-hot sequence of full kinase

## Status
- [ ] Ready to go