### PR TITLE
Test failures

### DIFF
--- a/kinoml/features/core.py
+++ b/kinoml/features/core.py
@@ -708,7 +708,13 @@ class HashFeaturizer(BaseFeaturizer):
 
 
 class NullFeaturizer(BaseFeaturizer):
-    def _featurize(self, systems: Iterable[System], processes=1, chunksize=None) -> object:
+    def _featurize(
+            self,
+            systems: Iterable[System],
+            processes=1,
+            chunksize=None,
+            keep: bool = None,
+    ) -> object:
         return systems
 
 

--- a/kinoml/tests/datasets/test_core.py
+++ b/kinoml/tests/datasets/test_core.py
@@ -105,7 +105,7 @@ def test_datasetprovider_exporter_single_tensor_different_shapes():
 
     arrays = dataset.to_dict_of_arrays()
     X_keys = [k for k in arrays.keys() if k.startswith("X")]
-    assert sorted(X_keys) == ["X_s0", "X_s1"]
+    assert sorted(X_keys) == ["X_s0_", "X_s1_"]
     for X_key, smi in zip(X_keys, smiles):
         assert arrays[X_key].shape == (53, len(smi))
 

--- a/kinoml/tests/datasets/test_core.py
+++ b/kinoml/tests/datasets/test_core.py
@@ -144,9 +144,9 @@ def test_datasetprovider_exporter_multiple_subtensors():
 
     arrays = dataset.to_dict_of_arrays()
     X_keys = [k for k in arrays.keys() if k.startswith("X")]
-    assert sorted(X_keys) == ["X_s0_a0", "X_s0_a1", "X_s1_a0", "X_s1_a1"]
-    assert arrays["X_s0_a0"].shape[0] == 512
-    assert arrays["X_s0_a1"].shape[0] == 1024
+    assert sorted(X_keys) == ["X_s0_a0_", "X_s0_a1_", "X_s1_a0_", "X_s1_a1_"]
+    assert arrays["X_s0_a0_"].shape[0] == 512
+    assert arrays["X_s0_a1_"].shape[0] == 1024
 
 
 def test_datasetprovider_awkward_exporter_single_tensor_same_shape():


### PR DESCRIPTION
## Description
This PR aims to fix failures in the unit tests.

## Todos
  - [x] fix NullFeaturizer
  - [x] fix test_datasetprovider_exporter_single_tensor_different_shapes
  - [x] fix test_datasetprovider_exporter_multiple_subtensors
  - [x] fix fix test_datasetprovider_exporter_multiple_subtensors
  - [ ] implement test_access_by_index_roundtrip

## Questions
- [ ] The only failure left is about test_access_by_index_roundtrip, which is simply not implemented. However, I am not quite sure how to implement this test. @t-kimber do you know what this is about?

## Status
- [ ] Ready to go