### PR TITLE
fix kinomescan test for consistent ordering

### DIFF
--- a/kinoml/datasets/kinomescan/pkis2.py
+++ b/kinoml/datasets/kinomescan/pkis2.py
@@ -61,7 +61,6 @@ class PKIS2DatasetProvider(KinomeScanDatasetProvider):
         TODO:
 
         - Investigate lazy access and object generation
-        - Review accuracy of item access by indices (correlative order?)
         """
         filename = cls._download_to_cache_or_retrieve(path_or_url)
         df = cls._read_dataframe(filename)

--- a/kinoml/tests/datasets/test_kinomescan.py
+++ b/kinoml/tests/datasets/test_kinomescan.py
@@ -19,10 +19,12 @@ def test_pkis2():
     provider = PKIS2DatasetProvider.from_source()
     assert len(provider.measurements) == 261_870
     assert (provider.measurements[0].values == 14.0).all()
-
-
-def test_access_by_index_roundtrip():
-    """
-    Check notes in `kinoml.dataset.kinomescan.pkis2.PKIS2DatasetProvider.from_source()`
-    """
-    raise NotImplementedError("This test is pending and important!")
+    # check order in provider matches order in file
+    assert (  # matches line 43 in file
+        provider[17051].system.ligand.name
+        == "O=C1NC(C2=C(C3=CC=CC=C3)C=C4C(C(C=C(O)C=C5)=C5N4)=C21)=O"
+    )
+    assert (  # matches line 44 in file
+        provider[17052].system.ligand.name
+        == "CN(N=C1)C=C1C(C=C2)=NN3C2=NN=C3[C@@H](C)C4=CC=C(N=CC=C5)C5=C4"
+    )


### PR DESCRIPTION
## Description
This PR adds a test for consistent ordering of data from the PKIS2DatasetProvider.

## Todos
  - [x] add test

## Status
- [x] Ready to go