### PR TITLE
Awkward array with parquet files

### DIFF
--- a/kinoml/features/ligand.py
+++ b/kinoml/features/ligand.py
@@ -163,7 +163,7 @@ class MorganFingerprintFeaturizer(SingleLigandFeaturizer):
         # otherwise, we should force that behaviour ourselves!
         ligand = self._find_ligand(system).to_rdkit()
         fp = Morgan(ligand, radius=self.radius, nBits=self.nbits)
-        return np.asarray(fp, dtype="bool")
+        return np.asarray(fp, dtype="int64")
 
 
 class OneHotSMILESFeaturizer(BaseOneHotEncodingFeaturizer, SingleLigandFeaturizer):


### PR DESCRIPTION
## Description
Change type of morgan vector to int64 (vs bool) to have the same type and not a union of different type (e.g. bool and float).

## Status
- [ ] Ready to go