### PR TITLE
Add klifs data to CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
           auto-activate-base: false
           use-mamba: true
 
+      - name: Cache klifs data
+        uses: actions/cache@v2
+        with:
+          path:
+            python -c 'from appdirs import user_cache_dir; print(user_cache_dir())'
+          key: ${{ runner.os }}-${{ hashFiles('klifs_*_db.csv') }}
+
       - name: Additional info about the build
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Run notebook tests
         shell: bash -l {0}
         run: |
-          PYTEST_ARGS="--nbval-lax --current-env --dist loadscope --numprocesses 2"
+          PYTEST_ARGS="--nbval-lax --nbval-cell-timeout 4000 --current-env --dist loadscope --numprocesses 2"
           pytest $PYTEST_ARGS examples/*.ipynb
 
       - name: CodeCov

--- a/examples/docking.ipynb
+++ b/examples/docking.ipynb
@@ -16,6 +16,8 @@
    "outputs": [],
    "source": [
     "import logging\n",
+    "from appdirs import user_cache_dir\n",
+    "\n",
     "from openeye import oechem\n",
     "\n",
     "from kinoml.core.ligands import Ligand\n",
@@ -76,7 +78,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d53abdc20c71490fa2eca830240d1ef0",
+       "model_id": "f84c1fcafd2c44d88579ae72d9bb7b79",
        "version_major": 2,
        "version_minor": 0
       },
@@ -99,7 +101,11 @@
     }
    ],
    "source": [
-    "docking_featurizer = OEHybridDockingFeaturizer(use_multiprocessing=False)\n",
+    "docking_featurizer = OEHybridDockingFeaturizer(\n",
+    "    cache_dir=user_cache_dir(),\n",
+    "    output_dir=user_cache_dir(),\n",
+    "    use_multiprocessing=False,\n",
+    ")\n",
     "systems = docking_featurizer.featurize([protein_ligand_complex])\n",
     "systems"
    ]
@@ -145,7 +151,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "54784151b9424d0ea4945fe20f19cec1",
+       "model_id": "aee1054897f2409bb0a887adb804f5d9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -168,7 +174,11 @@
     }
    ],
    "source": [
-    "docking_featurizer = OEKLIFSKinaseHybridDockingFeaturizer(use_multiprocessing=False)\n",
+    "docking_featurizer = OEKLIFSKinaseHybridDockingFeaturizer(\n",
+    "    cache_dir=user_cache_dir(),\n",
+    "    output_dir=user_cache_dir(),\n",
+    "    use_multiprocessing=False,\n",
+    ")\n",
     "systems = docking_featurizer.featurize([kinase_ligand_complex])\n",
     "systems"
    ]


### PR DESCRIPTION
## Description
Currently, testing the KLIFS complex featurizers in the CI takes quite some time, since the KLIFS queries in the _pre_featurize method will need to download all data on every push. This PR aims to enable persistent caching of the results for the CI.

## Todos
  - [ ] update docking notebook to specify cache_dir
  - [ ] increase notebook cell timeout to allow finishing of the cells, when cached files are not present yes
  - [ ] include cache in CI
  - [ ] CI execution time improves

## Status
- [ ] Ready to go