### PR TITLE
Update mdanalysis dependency

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -55,8 +55,6 @@ dependencies:
       - https://github.com/ValentinFigue/Sklearn_PyTorch/archive/1b56a43e41de331ecdf73d08418f75bb34c9fa06.tar.gz
       # OpenCADD
       - https://github.com/volkamerlab/opencadd/archive/master.tar.gz
-      # ProDy
-      - prody==1.10.11
       # Docs
       # core
       - sphinx~=2.4.0

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -27,6 +27,7 @@ dependencies:
   - papermill 2.2.*
   - matplotlib-base
   - ruamel.yaml
+  - mdanalysis >=2.0.0
 
   # Development
   - jupyterlab
@@ -75,5 +76,3 @@ dependencies:
       - sphinx-material
       # local building
       - sphinx-autobuild
-      # no stable release yet with support for serialization
-      - MDAnalysis==2.0.0b0


### PR DESCRIPTION
## Description
MDAnalysis 2.0.0 was released for conda-forge. This PR moves the mdanalysis dependency to conda-forge.

## Todos
- [x] move mdanalysis dependency to conda-forge

## Other
- [x] remove prody, which is used in the deprecated homology modeling module #75 

## Status
- [ ] Ready to go