### PR TITLE
Fix multiprocessing of structural featurizers

### DIFF
--- a/kinoml/features/complexes.py
+++ b/kinoml/features/complexes.py
@@ -8,10 +8,10 @@ import logging
 from pathlib import Path
 from typing import Union, Tuple, Iterable, List
 
+import MDAnalysis as mda
 from MDAnalysis.core import universe
 
 from .core import ParallelBaseFeaturizer
-from ..core.proteins import ProteinStructure
 from ..core.sequences import Biosequence
 from ..core.systems import ProteinSystem, ProteinLigandComplex
 
@@ -123,7 +123,7 @@ class OEHybridDockingFeaturizer(ParallelBaseFeaturizer):
         )
 
         logging.debug("Generating new MDAnalysis universe ...")
-        structure = ProteinStructure.from_file(file_path)
+        structure = mda.Universe(file_path, in_memory=True)
 
         if not self.output_dir:
             logging.debug("Removing structure file ...")
@@ -860,7 +860,7 @@ class OEKLIFSKinaseApoFeaturizer(OEHybridDockingFeaturizer):
         )
 
         logging.debug("Generating new MDAnalysis universe ...")
-        structure = ProteinStructure.from_file(file_path)
+        structure = mda.Universe(file_path, in_memory=True)
 
         if not self.output_dir:
             logging.debug("Removing structure file ...")
@@ -1602,7 +1602,7 @@ class OEKLIFSKinaseHybridDockingFeaturizer(OEKLIFSKinaseApoFeaturizer):
         )
 
         logging.debug("Generating new MDAnalysis universe ...")
-        structure = ProteinStructure.from_file(file_path)
+        structure = mda.Universe(file_path, in_memory=True)
 
         if not self.output_dir:
             logging.debug("Removing structure file ...")


### PR DESCRIPTION
## Description
@corey-taylor discovered a bug leading to never finishing processes when using multi-processing in the structural featurizers without specifying an output directory. In this case, the generated openeye molecule object will be written to disk as a PDB file, read back in as MDAnalysis universe, the file will be deleted and finally, the universe returned. This is the intended behavior when not specifying an output directory since the user was not interested in the file. However, standard MDAnalysis readers do not load into memory. Hence, during serialization in the multiprocessing scheme, the MDAnalysis reader will miss the file, since it has been deleted.

This PR makes sure we read the generated structure into memory. Thus, we can delete the file and still serialize the universe.

## Questions
- [ ] @corey-taylor Can you check this out and run the docking notebook with this branch?

## Status
- [ ] Ready to go