### PR TITLE
Posit template

### DIFF
--- a/kinoml/databases/pdb.py
+++ b/kinoml/databases/pdb.py
@@ -51,8 +51,8 @@ def download_pdb_structure(pdb_id, directory=user_cache_dir()):
 
     Returns
     -------
-    : bool
-        True if successful, else False.
+    : Path or False
+        The path to the the download file if successful, else False.
     """
     from pathlib import Path
 
@@ -64,16 +64,16 @@ def download_pdb_structure(pdb_id, directory=user_cache_dir()):
     pdb_path = LocalFileStorage.rcsb_structure_pdb(pdb_id, directory)
     if not pdb_path.is_file():
         if FileDownloader.rcsb_structure_pdb(pdb_id, directory):
-            return True
+            return pdb_path
     else:
-        return True
+        return pdb_path
 
     # check for structure in CIF format
     cif_path = LocalFileStorage.rcsb_structure_cif(pdb_id, directory)
     if not cif_path.is_file():
         if FileDownloader.rcsb_structure_cif(pdb_id, directory):
-            return True
+            return cif_path
     else:
-        return True
+        return cif_path
 
     return False

--- a/kinoml/databases/pdb.py
+++ b/kinoml/databases/pdb.py
@@ -1,5 +1,7 @@
 from typing import Iterable
 
+from appdirs import user_cache_dir
+
 
 def smiles_from_pdb(ligand_ids: Iterable[str]) -> dict:
     """
@@ -33,3 +35,45 @@ def smiles_from_pdb(ligand_ids: Iterable[str]) -> dict:
             pass
 
     return ligands
+
+
+def download_pdb_structure(pdb_id, directory=user_cache_dir()):
+    """
+    Download a PDB structure. If the structure is not available in PDB format, it will be download
+    in CIF format.
+
+    Parameters
+    ----------
+    pdb_id: str
+        The PDB ID of interest.
+    directory: str or Path, default=user_cache_dir
+        The directory for saving the downloaded structure.
+
+    Returns
+    -------
+    : bool
+        True if successful, else False.
+    """
+    from pathlib import Path
+
+    from ..utils import LocalFileStorage, FileDownloader
+
+    directory = Path(directory)
+
+    # check for structure in PDB format
+    pdb_path = LocalFileStorage.rcsb_structure_pdb(pdb_id, directory)
+    if not pdb_path.is_file():
+        if FileDownloader.rcsb_structure_pdb(pdb_id, directory):
+            return True
+    else:
+        return True
+
+    # check for structure in CIF format
+    cif_path = LocalFileStorage.rcsb_structure_cif(pdb_id, directory)
+    if not cif_path.is_file():
+        if FileDownloader.rcsb_structure_cif(pdb_id, directory):
+            return True
+    else:
+        return True
+
+    return False

--- a/kinoml/databases/pdb.py
+++ b/kinoml/databases/pdb.py
@@ -52,7 +52,7 @@ def download_pdb_structure(pdb_id, directory=user_cache_dir()):
     Returns
     -------
     : Path or False
-        The path to the the download file if successful, else False.
+        The path to the the downloaded file if successful, else False.
     """
     from pathlib import Path
 

--- a/kinoml/features/complexes.py
+++ b/kinoml/features/complexes.py
@@ -74,7 +74,7 @@ class OEComplexFeaturizer(OEBaseModelingFeaturizer):
 
     _SUPPORTED_TYPES = (ProteinLigandComplex,)
 
-    def _featurize_one(self, system: ProteinLigandComplex) -> Universe:
+    def _featurize_one(self, system: ProteinLigandComplex) -> Union[Universe, None]:
         """
         Prepare a protein structure.
 
@@ -85,8 +85,8 @@ class OEComplexFeaturizer(OEBaseModelingFeaturizer):
 
         Returns
         -------
-        : Universe
-            An MDAnalysis universe of the featurized system.
+        : Universe or None
+            An MDAnalysis universe of the featurized system. None if no design unit was found.
         """
         import MDAnalysis as mda
 
@@ -107,6 +107,9 @@ class OEComplexFeaturizer(OEBaseModelingFeaturizer):
             ligand_name=system_dict["protein_expo_id"],
             model_loops_and_caps=False if system_dict["protein_sequence"] else True,
         )  # if sequence is given model loops and caps separately later
+        if not design_unit:
+            logging.debug("No design unit found, returning None!")
+            return None
 
         logging.debug("Extracting design unit components ...")
         protein, solvent, ligand = self._get_components(
@@ -232,7 +235,8 @@ class OEHybridDockingFeaturizer(OEBaseModelingFeaturizer):
         Returns
         -------
         : Universe or None
-            An MDAnalysis universe of the featurized system. None if no docking pose was found.
+            An MDAnalysis universe of the featurized system. None if no design unit or docking
+            pose was found.
         """
         import MDAnalysis as mda
         from openeye import oechem, oedocking
@@ -255,6 +259,9 @@ class OEHybridDockingFeaturizer(OEBaseModelingFeaturizer):
             ligand_name=system_dict["protein_expo_id"],
             model_loops_and_caps=False if system_dict["protein_sequence"] else True,
         )  # if sequence is given model loops and caps separately later
+        if not design_unit:
+            logging.debug("No design unit found, returning None!")
+            return None
 
         logging.debug("Extracting design unit components ...")
         protein, solvent, ligand = self._get_components(
@@ -396,7 +403,8 @@ class OEFredDockingFeaturizer(OEBaseModelingFeaturizer):
         Returns
         -------
         : Universe or None
-            An MDAnalysis universe of the featurized system. None if no docking pose was found.
+            An MDAnalysis universe of the featurized system. None if no design unit or docking
+            pose was found.
         """
         import MDAnalysis as mda
         from openeye import oechem, oedocking
@@ -424,6 +432,9 @@ class OEFredDockingFeaturizer(OEBaseModelingFeaturizer):
         protein, solvent, ligand = self._get_components(
             design_unit, system_dict["protein_chain_id"]
         )
+        if not design_unit:
+            logging.debug("No design unit found, returning None!")
+            return None
 
         logging.debug("Defining binding site ...")
         box_molecule = resids_to_box_molecule(protein, system.protein.pocket_resids)
@@ -595,7 +606,8 @@ class OEPositDockingFeaturizer(OEBaseModelingFeaturizer):
         Returns
         -------
         : Universe or None
-            An MDAnalysis universe of the featurized system. None if no docking pose was found.
+            An MDAnalysis universe of the featurized system. None if no design unit or docking
+            pose was found.
         """
         import MDAnalysis as mda
         from openeye import oechem, oedocking
@@ -623,6 +635,9 @@ class OEPositDockingFeaturizer(OEBaseModelingFeaturizer):
             ligand_name=system_dict["protein_expo_id"],
             model_loops_and_caps=False if system_dict["protein_sequence"] else True,
         )  # if sequence is given model loops and caps separately later
+        if not design_unit:
+            logging.debug("No design unit found, returning None!")
+            return None
 
         logging.debug("Extracting design unit components ...")
         protein, solvent, ligand = self._get_components(
@@ -644,6 +659,9 @@ class OEPositDockingFeaturizer(OEBaseModelingFeaturizer):
                 ligand_name=system_dict["docking_template_expo_id"],
                 model_loops_and_caps=False,
             )
+            if not docking_template_du:
+                logging.debug("No design unit found for docking template, returning None!")
+                return None
 
             logging.debug("Retrieving docking template components ...")
             docking_template_du.GetComponents(

--- a/kinoml/features/complexes.py
+++ b/kinoml/features/complexes.py
@@ -662,6 +662,7 @@ class OEPositDockingFeaturizer(OEBaseModelingFeaturizer):
 
             logging.debug("Extracting docking template ligand ...")
             split_options = oechem.OESplitMolComplexOptions()
+            split_options.SetSplitCovalent(True)
             docking_template_ligand = list(oechem.OEGetMolComplexComponents(
                 docking_template, split_options, split_options.GetLigandFilter())
             )[0]

--- a/kinoml/features/complexes.py
+++ b/kinoml/features/complexes.py
@@ -606,8 +606,8 @@ class OEPositDockingFeaturizer(OEBaseModelingFeaturizer):
         Returns
         -------
         : Universe or None
-            An MDAnalysis universe of the featurized system. None if no design unit or docking
-            pose was found.
+            An MDAnalysis universe of the featurized system. None if no design unit, docking
+            template ligand or docking pose was found.
         """
         import MDAnalysis as mda
         from openeye import oechem, oedocking
@@ -681,9 +681,13 @@ class OEPositDockingFeaturizer(OEBaseModelingFeaturizer):
             logging.debug("Extracting docking template ligand ...")
             split_options = oechem.OESplitMolComplexOptions()
             split_options.SetSplitCovalent(True)
-            docking_template_ligand = list(oechem.OEGetMolComplexComponents(
-                docking_template, split_options, split_options.GetLigandFilter())
-            )[0]
+            try:
+                docking_template_ligand = list(oechem.OEGetMolComplexComponents(
+                    docking_template, split_options, split_options.GetLigandFilter())
+                )[0]
+            except IndexError:
+                logging.debug("No docking template ligand could be extracted, returning None!")
+                return None
 
             logging.debug("Transferring docking template ligand to protein structure ...")
             oechem.OEUpdateDesignUnit(

--- a/kinoml/features/core.py
+++ b/kinoml/features/core.py
@@ -957,7 +957,7 @@ class OEBaseModelingFeaturizer(ParallelBaseFeaturizer):
             has_ligand: bool,
             ligand_name: Union[str, None],
             model_loops_and_caps: bool,
-    ) -> oechem.OEDesignUnit:
+    ) -> Union[oechem.OEDesignUnit, None]:
         """
         Get an OpenEye design unit based on the given input.
 
@@ -981,8 +981,8 @@ class OEBaseModelingFeaturizer(ParallelBaseFeaturizer):
 
         Returns
         -------
-        design_unit: oechem.OEDesignUnit
-            The design unit.
+        design_unit: oechem.OEDesignUnit or None
+            The design unit or None if no design unit was found.
         """
         from openeye import oechem
 
@@ -1005,15 +1005,18 @@ class OEBaseModelingFeaturizer(ParallelBaseFeaturizer):
         )
         if not design_unit_path.is_file():
             logging.debug("Generating design unit ...")
-            design_unit = prepare_structure(
-                structure,
-                loop_db=self.loop_db if model_loops_and_caps else None,
-                has_ligand=has_ligand,
-                ligand_name=ligand_name,
-                chain_id=chain_id,
-                alternate_location=alternate_location,
-                cap_termini=True if model_loops_and_caps else False
-            )
+            try:
+                design_unit = prepare_structure(
+                    structure,
+                    loop_db=self.loop_db if model_loops_and_caps else None,
+                    has_ligand=has_ligand,
+                    ligand_name=ligand_name,
+                    chain_id=chain_id,
+                    alternate_location=alternate_location,
+                    cap_termini=True if model_loops_and_caps else False
+                )
+            except ValueError:
+                return None
             logging.debug("Writing design unit ...")
             oechem.OEWriteDesignUnit(str(design_unit_path), design_unit)
         # re-reading design unit helps proper capping of e.g. 2itz

--- a/kinoml/features/protein.py
+++ b/kinoml/features/protein.py
@@ -4,6 +4,7 @@ Featurizers that mostly concern protein-based models
 from __future__ import annotations
 from collections import Counter
 import logging
+from typing import Union
 
 import numpy as np
 
@@ -119,7 +120,7 @@ class OEProteinStructureFeaturizer(OEBaseModelingFeaturizer):
 
     _SUPPORTED_TYPES = (ProteinSystem,)
 
-    def _featurize_one(self, system: ProteinSystem) -> Universe:
+    def _featurize_one(self, system: ProteinSystem) -> Union[Universe, None]:
         """
         Prepare a protein structure.
 
@@ -130,8 +131,8 @@ class OEProteinStructureFeaturizer(OEBaseModelingFeaturizer):
 
         Returns
         -------
-        : Universe
-            An MDAnalysis universe of the featurized system.
+        : Universe or None
+            An MDAnalysis universe of the featurized system. None if no design unit was found.
         """
         import MDAnalysis as mda
 
@@ -152,6 +153,9 @@ class OEProteinStructureFeaturizer(OEBaseModelingFeaturizer):
             ligand_name=system_dict["protein_expo_id"],
             model_loops_and_caps=False if system_dict["protein_sequence"] else True,
         )  # if sequence is given model loops and caps separately later
+        if not design_unit:
+            logging.debug("No design unit found, returning None!")
+            return None
 
         logging.debug("Extracting design unit components ...")
         protein, solvent = self._get_components(design_unit, system_dict["protein_chain_id"])[:-1]

--- a/kinoml/tests/databases/test_pdb.py
+++ b/kinoml/tests/databases/test_pdb.py
@@ -2,6 +2,7 @@
 Test pdb functionalities of `kinoml.databases`
 """
 from contextlib import contextmanager
+from pathlib import PosixPath
 import pytest
 
 
@@ -41,27 +42,27 @@ def test_smiles_from_pdb(pdb_ids, expectation, smiles_list):
 
 
 @pytest.mark.parametrize(
-    "pdb_id, success",
+    "pdb_id, return_type",
     [
         (
             "4YNE",  # PDB and CIF format available
-            True,
+            PosixPath,
         ),
         (
             "1BOS",  # only CIF format available
-            True,
+            PosixPath,
         ),
         (
             "XXXX",  # wrong code
-            False,
+            bool,
         ),
     ],
 )
-def test_download_pdb_structure(pdb_id, success):
+def test_download_pdb_structure(pdb_id, return_type):
     """Try to download PDB structures."""
     from tempfile import TemporaryDirectory
 
     from kinoml.databases.pdb import download_pdb_structure
 
     with TemporaryDirectory() as temporary_directory:
-        assert download_pdb_structure(pdb_id, temporary_directory) == success
+        assert isinstance(download_pdb_structure(pdb_id, temporary_directory), return_type)

--- a/kinoml/tests/databases/test_pdb.py
+++ b/kinoml/tests/databases/test_pdb.py
@@ -4,8 +4,6 @@ Test pdb functionalities of `kinoml.databases`
 from contextlib import contextmanager
 import pytest
 
-from kinoml.databases.pdb import smiles_from_pdb
-
 
 @contextmanager
 def does_not_raise():
@@ -34,7 +32,36 @@ def does_not_raise():
 )
 def test_smiles_from_pdb(pdb_ids, expectation, smiles_list):
     """Compare results for expected SMILES."""
+    from kinoml.databases.pdb import smiles_from_pdb
+
     with expectation:
         ligands = smiles_from_pdb(pdb_ids)
         for pdb_id, smiles in zip(pdb_ids, smiles_list):
             assert ligands[pdb_id] == smiles
+
+
+@pytest.mark.parametrize(
+    "pdb_id, success",
+    [
+        (
+            "4YNE",  # PDB and CIF format available
+            True,
+        ),
+        (
+            "1BOS",  # only CIF format available
+            True,
+        ),
+        (
+            "XXXX",  # wrong code
+            False,
+        ),
+    ],
+)
+def test_download_pdb_structure(pdb_id, success):
+    """Try to download PDB structures."""
+    from tempfile import TemporaryDirectory
+
+    from kinoml.databases.pdb import download_pdb_structure
+
+    with TemporaryDirectory() as temporary_directory:
+        assert download_pdb_structure(pdb_id, temporary_directory) == success


### PR DESCRIPTION
## Description
This PR adds the possibility to specify a different docking template for the `OEPositDockingFeaturizer`. The docking template will be superposed to the actual protein structure used during Posit docking and subsequently, the docking template ligand transferred. If successful in the docking benchmark, this PR may be merged. In general, this behavior could also be implemented in the `OEHybridDockingFeaturizer`

## Todos
  - [x] implement needed changes
  - [x] add rescoring of docked molecules 
  - [ ] check behavior in benchmark

## Status
- [ ] Ready to go