### PR TITLE
Update providers for proper toolkit and protein_type handling

### DIFF
--- a/examples/OpenEye_structural_featurizer.ipynb
+++ b/examples/OpenEye_structural_featurizer.ipynb
@@ -69,10 +69,15 @@
      "text": [
       "Given systems with exactly one protein, prepare the protein structure by:\n",
       "\n",
-      " - modeling missing loops\n",
+      " - modeling missing loops with OESpruce according to the PDB header unless\n",
+      "   a custom sequence is specified via the `uniprot_id` or `sequence`\n",
+      "   attribute in the protein component (see below), missing sequences at\n",
+      "   N- and C-termini are not modeled\n",
       " - building missing side chains\n",
-      " - mutations, if `uniprot_id` or `sequence` attribute is provided for\n",
-      "   the protein component (see below)\n",
+      " - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`\n",
+      "   attribute is provided for the protein component alteration will be\n",
+      "   modeled with OESpruce, if an alteration could not be modeled, the\n",
+      "   corresponding mismatch in the structure will be deleted\n",
       " - removing everything but protein and water\n",
       " - protonation at pH 7.4\n",
       "\n",
@@ -214,7 +219,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8ec25f2454394be2802d4c9f272ecfd2",
+       "model_id": "46546397b38a4b87aa3e9675174939ad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -224,68 +229,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: Failed to find residue GLU139.\n",
-      "Warning: Failed to find residue HIS140.\n",
-      "Warning: Failed to find residue HIS141.\n",
-      "Warning: Failed to find residue HIS142.\n",
-      "Warning: Failed to find residue HIS143.\n",
-      "Warning: Failed to find residue HIS144.\n",
-      "Warning: Failed to find residue HIS145.\n",
-      "DPI: 0.17, RFree: 0.29, Resolution: 1.90\n",
-      "Processing BU # 1 with title: PH 6 ANTIGEN, chains AB, alt: A\n",
-      "Found unresolved N-terminal with 1 residues before ASN 2   A 1  , with sequence M\n",
-      "Found unresolved C-terminal with 8 residues after GLY 137   A 1  , with sequence LEHHHHHH\n",
-      "Processing BU # 2 with title: PH 6 ANTIGEN, chains AB, alt: B\n",
-      "Found unresolved N-terminal with 1 residues before ASN 2   A 1  , with sequence M\n",
-      "Found unresolved C-terminal with 8 residues after GLY 137   A 1  , with sequence LEHHHHHH\n",
-      "Warning: Failed to find residue GLU139.\n",
-      "Warning: Failed to find residue HIS140.\n",
-      "Warning: Failed to find residue HIS141.\n",
-      "Warning: Failed to find residue HIS142.\n",
-      "Warning: Failed to find residue HIS143.\n",
-      "Warning: Failed to find residue HIS144.\n",
-      "Warning: Failed to find residue HIS145.\n",
-      "DPI: 0.17, RFree: 0.29, Resolution: 1.90\n",
-      "Processing BU # 1 with title: PH 6 ANTIGEN, chains AB\n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n",
-      "   Falling back to charging other_ligands with OEMMFF94Charges\n",
-      "Warning: No BioAssembly transforms found, using input molecule as biounit: PH 6 ANTIGEN(A)\n",
-      "Warning: Iridium - Structure: PH 6 ANTIGEN(A) has no REMARK data\n",
-      "Processing BU # 1 with title: PH 6 ANTIGEN(A), chains A\n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n",
-      "Warning: Failed to find residue GLU139.\n",
-      "Warning: Failed to find residue HIS140.\n",
-      "Warning: Failed to find residue HIS141.\n",
-      "Warning: Failed to find residue HIS142.\n",
-      "Warning: Failed to find residue HIS143.\n",
-      "Warning: Failed to find residue HIS144.\n",
-      "Warning: Failed to find residue HIS145.\n",
-      "DPI: 0.16, RFree: 0.29, Resolution: 1.90\n",
-      "Processing BU # 1 with title: PH 6 ANTIGEN, chains A\n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n",
-      "   Falling back to charging protein with OEMMFF94Charges\n",
-      "Attempting to build loop: D between GLY 75   A 0   and THR 77   A 0  \n",
-      "Increased two sided crop back length from 1 to 2 to accommodate the minimum loop length in database\n",
-      "Opened database /home/david/github/kinoml/kinoml/data/proteins/kinoml_tests_4f8o_spruce.loop_db\n",
-      "LoopDatabase Info: \n",
-      "    1 loops from RCSB last synced on 06-16-2021, were added to kinoml_tests_4f8o on 06-16-2021 using Spruce Toolkit 1.2.0.0\n",
-      "    The loop database was built with a max loop length of 22, a terminus crop length of 2. Regular secondary structures were excluded\n",
-      "Attempting to build loop: D between ASP 124   A 0   and SER 126   A 0  \n",
-      "Increased two sided crop back length from 1 to 2 to accommodate the minimum loop length in database\n",
-      "Opened database /home/david/github/kinoml/kinoml/data/proteins/kinoml_tests_4f8o_spruce.loop_db\n",
-      "LoopDatabase Info: \n",
-      "    1 loops from RCSB last synced on 06-16-2021, were added to kinoml_tests_4f8o on 06-16-2021 using Spruce Toolkit 1.2.0.0\n",
-      "    The loop database was built with a max loop length of 22, a terminus crop length of 2. Regular secondary structures were excluded\n",
-      "Warning: No BioAssembly transforms found, using input molecule as biounit: PH 6 ANTIGEN(A)\n",
-      "Warning: Iridium - Structure: PH 6 ANTIGEN(A) has no REMARK data\n",
-      "Processing BU # 1 with title: PH 6 ANTIGEN(A), chains A\n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n"
-     ]
     },
     {
      "data": {
@@ -413,10 +356,15 @@
       "Given systems with exactly one protein and one ligand, prepare the complex\n",
       "structure by:\n",
       "\n",
-      " - modeling missing loops\n",
+      " - modeling missing loops with OESpruce according to the PDB header unless\n",
+      "   a custom sequence is specified via the `uniprot_id` or `sequence`\n",
+      "   attribute in the protein component (see below), missing sequences at\n",
+      "   N- and C-termini are not modeled\n",
       " - building missing side chains\n",
-      " - mutations, if `uniprot_id` or `sequence` attribute is provided for the\n",
-      "   protein component (see below)\n",
+      " - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`\n",
+      "   attribute is provided for the protein component alteration will be\n",
+      "   modeled with OESpruce, if an alteration could not be modeled, the\n",
+      "   corresponding mismatch in the structure will be deleted\n",
       " - removing everything but protein, water and ligand of interest\n",
       " - protonation at pH 7.4\n",
       "\n",
@@ -539,7 +487,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5bf76177789342e4a5a99451601b96cb",
+       "model_id": "5ed545e3ba934fa0b4e7f0c5930d51f3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -549,39 +497,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: Failed to find residue GLU139.\n",
-      "Warning: Failed to find residue HIS140.\n",
-      "Warning: Failed to find residue HIS141.\n",
-      "Warning: Failed to find residue HIS142.\n",
-      "Warning: Failed to find residue HIS143.\n",
-      "Warning: Failed to find residue HIS144.\n",
-      "Warning: Failed to find residue HIS145.\n",
-      "DPI: 0.17, RFree: 0.29, Resolution: 1.90\n",
-      "Processing BU # 1 with title: PH 6 ANTIGEN, chains AB, alt: A\n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n",
-      "Processing BU # 2 with title: PH 6 ANTIGEN, chains AB, alt: B\n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n",
-      "Warning: Failed to find residue GLU139.\n",
-      "Warning: Failed to find residue HIS140.\n",
-      "Warning: Failed to find residue HIS141.\n",
-      "Warning: Failed to find residue HIS142.\n",
-      "Warning: Failed to find residue HIS143.\n",
-      "Warning: Failed to find residue HIS144.\n",
-      "Warning: Failed to find residue HIS145.\n",
-      "DPI: 0.17, RFree: 0.29, Resolution: 1.90\n",
-      "Processing BU # 1 with title: PH 6 ANTIGEN, chains AB\n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n",
-      "   Falling back to charging other_ligands with OEMMFF94Charges\n",
-      "Warning: No BioAssembly transforms found, using input molecule as biounit: PH 6 ANTIGEN(A)\n",
-      "Warning: Iridium - Structure: PH 6 ANTIGEN(A) has no REMARK data\n",
-      "Processing BU # 1 with title: PH 6 ANTIGEN(A), chains A\n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n"
-     ]
     },
     {
      "data": {
@@ -670,10 +585,15 @@
       "structure and dock the ligand into the prepared protein structure with\n",
       "one of OpenEye's docking algorithms:\n",
       "\n",
-      " - modeling missing loops\n",
+      " - modeling missing loops with OESpruce according to the PDB header unless\n",
+      "   a custom sequence is specified via the `uniprot_id` or `sequence`\n",
+      "   attribute in the protein component (see below), missing sequences at\n",
+      "   N- and C-termini are not modeled\n",
       " - building missing side chains\n",
-      " - mutations, if `uniprot_id` or `sequence` attribute is provided for the\n",
-      "   protein component (see below)\n",
+      " - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`\n",
+      "   attribute is provided for the protein component alteration will be\n",
+      "   modeled with OESpruce, if an alteration could not be modeled, the\n",
+      "   corresponding mismatch in the structure will be deleted\n",
       " - removing everything but protein, water and ligand of interest\n",
       " - protonation at pH 7.4\n",
       " - perform docking\n",
@@ -813,7 +733,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "750257fe06704e7ab9ad4dbcb7f8d8e9",
+       "model_id": "f1f62040805c4ae98cbf0cc41b2babfb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -828,16 +748,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Warning: Failed to find residue GLY-7.\n",
-      "Warning: Failed to find residue ALA-6.\n",
-      "Warning: Failed to find residue MET-5.\n",
-      "DPI: 0.12, RFree: 0.22, Resolution: 2.02\n",
-      "Processing BU # 1 with title: HIGH AFFINITY NERVE GROWTH FACTOR RECEPTOR, chains A, alt: A\n",
-      "Warning: For residue ARG 702   A 1   removing clashing solvent molecule HOH 908   A 2  \n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n",
-      "Processing BU # 2 with title: HIGH AFFINITY NERVE GROWTH FACTOR RECEPTOR, chains A, alt: B\n",
-      "Warning: For residue ARG 702   A 1   removing clashing solvent molecule HOH 908   A 2  \n",
-      "Warning: There was a problem building some missing pieces, built as much as was possible\n",
       "Warning: Failed to find residue GLY-7.\n",
       "Warning: Failed to find residue ALA-6.\n",
       "Warning: Failed to find residue MET-5.\n",
@@ -1191,7 +1101,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4.66 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+      "5.51 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
      ]
     }
    ],
@@ -1242,7 +1152,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4.18 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+      "5.04 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
      ]
     }
    ],
@@ -1293,7 +1203,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4min 11s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+      "4min 25s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
      ]
     }
    ],

--- a/examples/Schrodinger_structural_featurizer.ipynb
+++ b/examples/Schrodinger_structural_featurizer.ipynb
@@ -5,10 +5,10 @@
    "id": "39823951-54dc-4651-bd95-e9116badf2d6",
    "metadata": {
     "papermill": {
-     "duration": 0.05634,
-     "end_time": "2022-03-31T07:51:31.140708",
+     "duration": 0.077343,
+     "end_time": "2022-04-22T12:38:50.757842",
      "exception": false,
-     "start_time": "2022-03-31T07:51:31.084368",
+     "start_time": "2022-04-22T12:38:50.680499",
      "status": "completed"
     },
     "tags": []
@@ -22,10 +22,10 @@
    "id": "37b59918-0cad-4211-aa6a-d43a36f055a2",
    "metadata": {
     "papermill": {
-     "duration": 0.035272,
-     "end_time": "2022-03-31T07:51:31.218936",
+     "duration": 0.075231,
+     "end_time": "2022-04-22T12:38:50.909289",
      "exception": false,
-     "start_time": "2022-03-31T07:51:31.183664",
+     "start_time": "2022-04-22T12:38:50.834058",
      "status": "completed"
     },
     "tags": []
@@ -42,16 +42,16 @@
    "id": "ba3e7292-700b-424f-b382-73efb82b3ffd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:51:31.288127Z",
-     "iopub.status.busy": "2022-03-31T07:51:31.287820Z",
-     "iopub.status.idle": "2022-03-31T07:51:46.448066Z",
-     "shell.execute_reply": "2022-03-31T07:51:46.447171Z"
+     "iopub.execute_input": "2022-04-22T12:38:51.053426Z",
+     "iopub.status.busy": "2022-04-22T12:38:51.052720Z",
+     "iopub.status.idle": "2022-04-22T12:39:10.718673Z",
+     "shell.execute_reply": "2022-04-22T12:39:10.715608Z"
     },
     "papermill": {
-     "duration": 15.198126,
-     "end_time": "2022-03-31T07:51:46.450551",
+     "duration": 19.745161,
+     "end_time": "2022-04-22T12:39:10.725049",
      "exception": false,
-     "start_time": "2022-03-31T07:51:31.252425",
+     "start_time": "2022-04-22T12:38:50.979888",
      "status": "completed"
     },
     "tags": []
@@ -82,10 +82,10 @@
    "id": "b00d8b82-329d-4a6b-9fd2-54a5671533a9",
    "metadata": {
     "papermill": {
-     "duration": 0.033822,
-     "end_time": "2022-03-31T07:51:46.520644",
+     "duration": 0.092947,
+     "end_time": "2022-04-22T12:39:10.912999",
      "exception": false,
-     "start_time": "2022-03-31T07:51:46.486822",
+     "start_time": "2022-04-22T12:39:10.820052",
      "status": "completed"
     },
     "tags": []
@@ -99,10 +99,10 @@
    "id": "684afa3d-3f34-4cbe-ad12-8a089a526940",
    "metadata": {
     "papermill": {
-     "duration": 0.034348,
-     "end_time": "2022-03-31T07:51:46.588803",
+     "duration": 0.095627,
+     "end_time": "2022-04-22T12:39:11.233127",
      "exception": false,
-     "start_time": "2022-03-31T07:51:46.554455",
+     "start_time": "2022-04-22T12:39:11.137500",
      "status": "completed"
     },
     "tags": []
@@ -117,16 +117,16 @@
    "id": "8260c926-b2ad-4700-bb50-4056c2aa63ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:51:46.659443Z",
-     "iopub.status.busy": "2022-03-31T07:51:46.659189Z",
-     "iopub.status.idle": "2022-03-31T07:51:46.663863Z",
-     "shell.execute_reply": "2022-03-31T07:51:46.663228Z"
+     "iopub.execute_input": "2022-04-22T12:39:11.412971Z",
+     "iopub.status.busy": "2022-04-22T12:39:11.412237Z",
+     "iopub.status.idle": "2022-04-22T12:39:11.421543Z",
+     "shell.execute_reply": "2022-04-22T12:39:11.420182Z"
     },
     "papermill": {
-     "duration": 0.044547,
-     "end_time": "2022-03-31T07:51:46.668044",
+     "duration": 0.10818,
+     "end_time": "2022-04-22T12:39:11.432437",
      "exception": false,
-     "start_time": "2022-03-31T07:51:46.623497",
+     "start_time": "2022-04-22T12:39:11.324257",
      "status": "completed"
     },
     "tags": []
@@ -139,11 +139,15 @@
       "Given systems with exactly one protein and one ligand, prepare the complex\n",
       "structure by:\n",
       "\n",
-      " - modeling missing loops\n",
+      " - modeling missing loops with Prime according to the PDB header unless\n",
+      "   a custom sequence is specified via the `uniprot_id` or `sequence`\n",
+      "   attribute in the protein component (see below), missing sequences at\n",
+      "   N- and C-termini are not modeled\n",
       " - building missing side chains\n",
-      " - mutations, if `uniprot_id` or `sequence` attribute is provided for the\n",
-      "   protein component\n",
-      "   (see below)\n",
+      " - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`\n",
+      "   attribute is provided for the protein component alteration will be first\n",
+      "   deleted and subsequently the intended sequence modeled with Prime, if\n",
+      "   an alteration could not be modeled, a corresponding deletion will remain\n",
       " - removing everything but protein, water and ligand of interest\n",
       " - protonation at pH 7.4\n",
       "\n",
@@ -205,10 +209,10 @@
    "id": "11cc845a-cc1d-4f68-a5ef-0f634352dd2e",
    "metadata": {
     "papermill": {
-     "duration": 0.08538,
-     "end_time": "2022-03-31T07:51:46.787709",
+     "duration": 0.088236,
+     "end_time": "2022-04-22T12:39:11.611911",
      "exception": false,
-     "start_time": "2022-03-31T07:51:46.702329",
+     "start_time": "2022-04-22T12:39:11.523675",
      "status": "completed"
     },
     "tags": []
@@ -223,16 +227,16 @@
    "id": "f39650b8-ca2f-4791-939c-4ac4ae6a6af4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:51:46.852657Z",
-     "iopub.status.busy": "2022-03-31T07:51:46.852427Z",
-     "iopub.status.idle": "2022-03-31T07:51:46.855301Z",
-     "shell.execute_reply": "2022-03-31T07:51:46.854806Z"
+     "iopub.execute_input": "2022-04-22T12:39:11.735035Z",
+     "iopub.status.busy": "2022-04-22T12:39:11.734639Z",
+     "iopub.status.idle": "2022-04-22T12:39:11.739487Z",
+     "shell.execute_reply": "2022-04-22T12:39:11.738591Z"
     },
     "papermill": {
-     "duration": 0.035342,
-     "end_time": "2022-03-31T07:51:46.857838",
+     "duration": 0.065894,
+     "end_time": "2022-04-22T12:39:11.744234",
      "exception": false,
-     "start_time": "2022-03-31T07:51:46.822496",
+     "start_time": "2022-04-22T12:39:11.678340",
      "status": "completed"
     },
     "tags": []
@@ -249,16 +253,16 @@
    "id": "1983dcc6-8234-46f3-8ee4-e165576f71e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:51:46.918918Z",
-     "iopub.status.busy": "2022-03-31T07:51:46.918696Z",
-     "iopub.status.idle": "2022-03-31T07:51:46.922831Z",
-     "shell.execute_reply": "2022-03-31T07:51:46.922119Z"
+     "iopub.execute_input": "2022-04-22T12:39:11.864349Z",
+     "iopub.status.busy": "2022-04-22T12:39:11.863991Z",
+     "iopub.status.idle": "2022-04-22T12:39:11.870014Z",
+     "shell.execute_reply": "2022-04-22T12:39:11.869269Z"
     },
     "papermill": {
-     "duration": 0.039467,
-     "end_time": "2022-03-31T07:51:46.925902",
+     "duration": 0.073111,
+     "end_time": "2022-04-22T12:39:11.874327",
      "exception": false,
-     "start_time": "2022-03-31T07:51:46.886435",
+     "start_time": "2022-04-22T12:39:11.801216",
      "status": "completed"
     },
     "tags": []
@@ -279,16 +283,16 @@
    "id": "cee7ded4-954c-4d0d-8dd5-11c8db2de4d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:51:46.986270Z",
-     "iopub.status.busy": "2022-03-31T07:51:46.986048Z",
-     "iopub.status.idle": "2022-03-31T07:51:52.329216Z",
-     "shell.execute_reply": "2022-03-31T07:51:52.328478Z"
+     "iopub.execute_input": "2022-04-22T12:39:12.022456Z",
+     "iopub.status.busy": "2022-04-22T12:39:12.021840Z",
+     "iopub.status.idle": "2022-04-22T12:39:18.939760Z",
+     "shell.execute_reply": "2022-04-22T12:39:18.938837Z"
     },
     "papermill": {
-     "duration": 5.375113,
-     "end_time": "2022-03-31T07:51:52.331055",
+     "duration": 6.998201,
+     "end_time": "2022-04-22T12:39:18.941864",
      "exception": false,
-     "start_time": "2022-03-31T07:51:46.955942",
+     "start_time": "2022-04-22T12:39:11.943663",
      "status": "completed"
     },
     "tags": []
@@ -322,16 +326,16 @@
    "id": "5458d5a5-6358-4fd4-9d64-2e734569d1d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:51:52.391445Z",
-     "iopub.status.busy": "2022-03-31T07:51:52.391203Z",
-     "iopub.status.idle": "2022-03-31T07:51:52.396303Z",
-     "shell.execute_reply": "2022-03-31T07:51:52.395864Z"
+     "iopub.execute_input": "2022-04-22T12:39:19.008197Z",
+     "iopub.status.busy": "2022-04-22T12:39:19.007918Z",
+     "iopub.status.idle": "2022-04-22T12:39:19.012884Z",
+     "shell.execute_reply": "2022-04-22T12:39:19.012330Z"
     },
     "papermill": {
-     "duration": 0.036892,
-     "end_time": "2022-03-31T07:51:52.397797",
+     "duration": 0.040611,
+     "end_time": "2022-04-22T12:39:19.015376",
      "exception": false,
-     "start_time": "2022-03-31T07:51:52.360905",
+     "start_time": "2022-04-22T12:39:18.974765",
      "status": "completed"
     },
     "tags": []
@@ -346,10 +350,10 @@
    "id": "678a9610-0009-4b0e-b5b4-cd9fc79a2177",
    "metadata": {
     "papermill": {
-     "duration": 0.027223,
-     "end_time": "2022-03-31T07:51:52.453193",
+     "duration": 0.032172,
+     "end_time": "2022-04-22T12:39:19.079128",
      "exception": false,
-     "start_time": "2022-03-31T07:51:52.425970",
+     "start_time": "2022-04-22T12:39:19.046956",
      "status": "completed"
     },
     "tags": []
@@ -368,39 +372,21 @@
    "id": "8eb84eac-ca63-4b72-b938-c7efa55ec19c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:51:52.511836Z",
-     "iopub.status.busy": "2022-03-31T07:51:52.511624Z",
-     "iopub.status.idle": "2022-03-31T07:56:48.824408Z",
-     "shell.execute_reply": "2022-03-31T07:56:48.823714Z"
+     "iopub.execute_input": "2022-04-22T12:39:19.262711Z",
+     "iopub.status.busy": "2022-04-22T12:39:19.262206Z",
+     "iopub.status.idle": "2022-04-22T12:39:57.014777Z",
+     "shell.execute_reply": "2022-04-22T12:39:57.014012Z"
     },
     "papermill": {
-     "duration": 296.344579,
-     "end_time": "2022-03-31T07:56:48.826092",
+     "duration": 37.855662,
+     "end_time": "2022-04-22T12:39:57.026026",
      "exception": false,
-     "start_time": "2022-03-31T07:51:52.481513",
+     "start_time": "2022-04-22T12:39:19.170364",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JobId: lt10-0-62455dbf\n",
-      "JobId: lt10-1-62455dbf\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING mmpdb_write_ct: Atom 2077 of residue A:205 (AES ) has same name (H8_1) as a prior atom.\n",
-      "WARNING mmpdb_write_ct: Atom 2078 of residue A:205 (AES ) has same name (H8_2) as a prior atom.\n",
-      "WARNING mmpdb_write_ct: Atom 2480 of residue A:205 (AES ) has same name (H8_1) as a prior atom.\n",
-      "WARNING mmpdb_write_ct: Atom 2481 of residue A:205 (AES ) has same name (H8_2) as a prior atom.\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -425,16 +411,16 @@
    "id": "92d67821-7c0f-4a83-be41-55e5ddd0fa46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:56:48.889382Z",
-     "iopub.status.busy": "2022-03-31T07:56:48.889157Z",
-     "iopub.status.idle": "2022-03-31T07:56:48.893340Z",
-     "shell.execute_reply": "2022-03-31T07:56:48.892885Z"
+     "iopub.execute_input": "2022-04-22T12:39:57.092001Z",
+     "iopub.status.busy": "2022-04-22T12:39:57.091568Z",
+     "iopub.status.idle": "2022-04-22T12:39:57.099682Z",
+     "shell.execute_reply": "2022-04-22T12:39:57.098675Z"
     },
     "papermill": {
-     "duration": 0.037242,
-     "end_time": "2022-03-31T07:56:48.896452",
+     "duration": 0.049043,
+     "end_time": "2022-04-22T12:39:57.106980",
      "exception": false,
-     "start_time": "2022-03-31T07:56:48.859210",
+     "start_time": "2022-04-22T12:39:57.057937",
      "status": "completed"
     },
     "tags": []
@@ -460,10 +446,10 @@
    "id": "0e684725-a286-4e5a-bbed-c3cf314b7c41",
    "metadata": {
     "papermill": {
-     "duration": 0.027713,
-     "end_time": "2022-03-31T07:56:48.953161",
+     "duration": 0.078278,
+     "end_time": "2022-04-22T12:39:57.264779",
      "exception": false,
-     "start_time": "2022-03-31T07:56:48.925448",
+     "start_time": "2022-04-22T12:39:57.186501",
      "status": "completed"
     },
     "tags": []
@@ -478,16 +464,16 @@
    "id": "354f1e57-0e54-49b4-ab07-2e0f53b203c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:56:49.011431Z",
-     "iopub.status.busy": "2022-03-31T07:56:49.011220Z",
-     "iopub.status.idle": "2022-03-31T07:56:49.014998Z",
-     "shell.execute_reply": "2022-03-31T07:56:49.014530Z"
+     "iopub.execute_input": "2022-04-22T12:39:57.425866Z",
+     "iopub.status.busy": "2022-04-22T12:39:57.425440Z",
+     "iopub.status.idle": "2022-04-22T12:39:57.433659Z",
+     "shell.execute_reply": "2022-04-22T12:39:57.432682Z"
     },
     "papermill": {
-     "duration": 0.035723,
-     "end_time": "2022-03-31T07:56:49.017900",
+     "duration": 0.096334,
+     "end_time": "2022-04-22T12:39:57.440877",
      "exception": false,
-     "start_time": "2022-03-31T07:56:48.982177",
+     "start_time": "2022-04-22T12:39:57.344543",
      "status": "completed"
     },
     "tags": []
@@ -512,10 +498,10 @@
    "id": "5e0012c1-1895-47dc-b501-71f4b763477d",
    "metadata": {
     "papermill": {
-     "duration": 0.029014,
-     "end_time": "2022-03-31T07:56:49.075819",
+     "duration": 0.074663,
+     "end_time": "2022-04-22T12:39:57.591975",
      "exception": false,
-     "start_time": "2022-03-31T07:56:49.046805",
+     "start_time": "2022-04-22T12:39:57.517312",
      "status": "completed"
     },
     "tags": []
@@ -529,10 +515,10 @@
    "id": "163c82b1-1e07-447d-a1c6-bac356cbe031",
    "metadata": {
     "papermill": {
-     "duration": 0.029073,
-     "end_time": "2022-03-31T07:56:49.133888",
+     "duration": 0.079668,
+     "end_time": "2022-04-22T12:39:57.752808",
      "exception": false,
-     "start_time": "2022-03-31T07:56:49.104815",
+     "start_time": "2022-04-22T12:39:57.673140",
      "status": "completed"
     },
     "tags": []
@@ -547,16 +533,16 @@
    "id": "8528adcf-b340-491d-b5ff-575964bbbfea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:56:49.193158Z",
-     "iopub.status.busy": "2022-03-31T07:56:49.192917Z",
-     "iopub.status.idle": "2022-03-31T07:56:49.196348Z",
-     "shell.execute_reply": "2022-03-31T07:56:49.195878Z"
+     "iopub.execute_input": "2022-04-22T12:39:57.914360Z",
+     "iopub.status.busy": "2022-04-22T12:39:57.913953Z",
+     "iopub.status.idle": "2022-04-22T12:39:57.920415Z",
+     "shell.execute_reply": "2022-04-22T12:39:57.919480Z"
     },
     "papermill": {
-     "duration": 0.036636,
-     "end_time": "2022-03-31T07:56:49.199450",
+     "duration": 0.094733,
+     "end_time": "2022-04-22T12:39:57.927781",
      "exception": false,
-     "start_time": "2022-03-31T07:56:49.162814",
+     "start_time": "2022-04-22T12:39:57.833048",
      "status": "completed"
     },
     "tags": []
@@ -570,10 +556,15 @@
       "structure dock the ligand into its binding site identified by a\n",
       "co-crystallized ligand. The following steps will be performed:\n",
       "\n",
-      " - modeling missing loops\n",
+      " - modeling missing loops with Prime according to the PDB header unless\n",
+      "   a custom sequence is specified via the `uniprot_id` or `sequence`\n",
+      "   attribute in the protein component (see below), missing sequences at\n",
+      "   N- and C-termini are not modeled\n",
       " - building missing side chains\n",
-      " - mutations, if `uniprot_id` or `sequence` attribute is provided for the\n",
-      "   protein component (see below)\n",
+      " - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`\n",
+      "   attribute is provided for the protein component alteration will be first\n",
+      "   deleted and subsequently the intended sequence modeled with Prime, if\n",
+      "   an alteration could not be modeled, a corresponding deletion will remain\n",
       " - removing everything but protein, water and ligand of interest\n",
       " - protonation at pH 7.4\n",
       " - docking a ligand\n",
@@ -646,10 +637,10 @@
    "id": "3f10336d-6237-480c-a753-7c68bc6e3e2c",
    "metadata": {
     "papermill": {
-     "duration": 0.028918,
-     "end_time": "2022-03-31T07:56:49.258287",
+     "duration": 0.075391,
+     "end_time": "2022-04-22T12:39:58.079576",
      "exception": false,
-     "start_time": "2022-03-31T07:56:49.229369",
+     "start_time": "2022-04-22T12:39:58.004185",
      "status": "completed"
     },
     "tags": []
@@ -664,16 +655,16 @@
    "id": "25ec8a4c-a609-4810-adcd-9a4af11bf5ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:56:49.314990Z",
-     "iopub.status.busy": "2022-03-31T07:56:49.314780Z",
-     "iopub.status.idle": "2022-03-31T07:56:49.317446Z",
-     "shell.execute_reply": "2022-03-31T07:56:49.316997Z"
+     "iopub.execute_input": "2022-04-22T12:39:58.243624Z",
+     "iopub.status.busy": "2022-04-22T12:39:58.243213Z",
+     "iopub.status.idle": "2022-04-22T12:39:58.248464Z",
+     "shell.execute_reply": "2022-04-22T12:39:58.247415Z"
     },
     "papermill": {
-     "duration": 0.033347,
-     "end_time": "2022-03-31T07:56:49.319633",
+     "duration": 0.094271,
+     "end_time": "2022-04-22T12:39:58.254265",
      "exception": false,
-     "start_time": "2022-03-31T07:56:49.286286",
+     "start_time": "2022-04-22T12:39:58.159994",
      "status": "completed"
     },
     "tags": []
@@ -689,16 +680,16 @@
    "id": "20c215d2-dee7-4d85-a97b-85fbbadd4f36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:56:49.378871Z",
-     "iopub.status.busy": "2022-03-31T07:56:49.378667Z",
-     "iopub.status.idle": "2022-03-31T07:56:49.382305Z",
-     "shell.execute_reply": "2022-03-31T07:56:49.381860Z"
+     "iopub.execute_input": "2022-04-22T12:39:58.418615Z",
+     "iopub.status.busy": "2022-04-22T12:39:58.418126Z",
+     "iopub.status.idle": "2022-04-22T12:39:58.425444Z",
+     "shell.execute_reply": "2022-04-22T12:39:58.424380Z"
     },
     "papermill": {
-     "duration": 0.035235,
-     "end_time": "2022-03-31T07:56:49.384514",
+     "duration": 0.095417,
+     "end_time": "2022-04-22T12:39:58.431095",
      "exception": false,
-     "start_time": "2022-03-31T07:56:49.349279",
+     "start_time": "2022-04-22T12:39:58.335678",
      "status": "completed"
     },
     "tags": []
@@ -718,16 +709,16 @@
    "id": "c3294d21-7f6b-4e05-97a1-ecfae31230d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:56:49.443239Z",
-     "iopub.status.busy": "2022-03-31T07:56:49.443036Z",
-     "iopub.status.idle": "2022-03-31T07:56:49.446575Z",
-     "shell.execute_reply": "2022-03-31T07:56:49.446143Z"
+     "iopub.execute_input": "2022-04-22T12:39:58.591255Z",
+     "iopub.status.busy": "2022-04-22T12:39:58.590864Z",
+     "iopub.status.idle": "2022-04-22T12:39:58.597392Z",
+     "shell.execute_reply": "2022-04-22T12:39:58.596415Z"
     },
     "papermill": {
-     "duration": 0.035417,
-     "end_time": "2022-03-31T07:56:49.448536",
+     "duration": 0.095846,
+     "end_time": "2022-04-22T12:39:58.603791",
      "exception": false,
-     "start_time": "2022-03-31T07:56:49.413119",
+     "start_time": "2022-04-22T12:39:58.507945",
      "status": "completed"
     },
     "tags": []
@@ -746,16 +737,16 @@
    "id": "b3e703d3-b47d-4b37-ba7c-7847f5eecdbc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T07:56:49.509306Z",
-     "iopub.status.busy": "2022-03-31T07:56:49.509096Z",
-     "iopub.status.idle": "2022-03-31T08:04:58.650841Z",
-     "shell.execute_reply": "2022-03-31T08:04:58.650325Z"
+     "iopub.execute_input": "2022-04-22T12:39:58.765771Z",
+     "iopub.status.busy": "2022-04-22T12:39:58.765410Z",
+     "iopub.status.idle": "2022-04-22T12:44:07.332372Z",
+     "shell.execute_reply": "2022-04-22T12:44:07.331024Z"
     },
     "papermill": {
-     "duration": 489.173533,
-     "end_time": "2022-03-31T08:04:58.652395",
+     "duration": 248.653296,
+     "end_time": "2022-04-22T12:44:07.339348",
      "exception": false,
-     "start_time": "2022-03-31T07:56:49.478862",
+     "start_time": "2022-04-22T12:39:58.686052",
      "status": "completed"
     },
     "tags": []
@@ -765,14 +756,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JobId: lt10-0-62455edf\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Converted file: /scratch/lsftmp/6152749.tmpdir/tmpovx75qrg.mae\n"
+      "Converted file: /scratch/lsftmp/6525607.tmpdir/tmpq7th966w.mae\n"
      ]
     },
     {
@@ -786,22 +770,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JobId: lt10-0-62455fde\n",
-      "ExitStatus: finished\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Removing previous job files...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JobId: lt10-0-6245601f\n",
+      "JobId: lu04-0-6262a247\n",
       "ExitStatus: finished\n"
      ]
     },
@@ -834,10 +803,10 @@
    "id": "092d09db-9220-4b29-9efc-cab0e0210dbc",
    "metadata": {
     "papermill": {
-     "duration": 0.031488,
-     "end_time": "2022-03-31T08:04:58.720762",
+     "duration": 0.080771,
+     "end_time": "2022-04-22T12:44:07.506012",
      "exception": false,
-     "start_time": "2022-03-31T08:04:58.689274",
+     "start_time": "2022-04-22T12:44:07.425241",
      "status": "completed"
     },
     "tags": []
@@ -852,16 +821,16 @@
    "id": "9febec67-160a-4ac7-aaeb-a3defb113101",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:04:58.784595Z",
-     "iopub.status.busy": "2022-03-31T08:04:58.784369Z",
-     "iopub.status.idle": "2022-03-31T08:04:58.788456Z",
-     "shell.execute_reply": "2022-03-31T08:04:58.788016Z"
+     "iopub.execute_input": "2022-04-22T12:44:07.673680Z",
+     "iopub.status.busy": "2022-04-22T12:44:07.673115Z",
+     "iopub.status.idle": "2022-04-22T12:44:07.682537Z",
+     "shell.execute_reply": "2022-04-22T12:44:07.681347Z"
     },
     "papermill": {
-     "duration": 0.038857,
-     "end_time": "2022-03-31T08:04:58.791568",
+     "duration": 0.103157,
+     "end_time": "2022-04-22T12:44:07.692056",
      "exception": false,
-     "start_time": "2022-03-31T08:04:58.752711",
+     "start_time": "2022-04-22T12:44:07.588899",
      "status": "completed"
     },
     "tags": []
@@ -887,10 +856,10 @@
    "id": "c3ff444f-289c-4bdc-b342-9beaefb554eb",
    "metadata": {
     "papermill": {
-     "duration": 0.030622,
-     "end_time": "2022-03-31T08:04:58.854265",
+     "duration": 0.078904,
+     "end_time": "2022-04-22T12:44:07.856264",
      "exception": false,
-     "start_time": "2022-03-31T08:04:58.823643",
+     "start_time": "2022-04-22T12:44:07.777360",
      "status": "completed"
     },
     "tags": []
@@ -905,16 +874,16 @@
    "id": "f2147b48-ded0-4cc8-acc1-78f976117b8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:04:58.915687Z",
-     "iopub.status.busy": "2022-03-31T08:04:58.915478Z",
-     "iopub.status.idle": "2022-03-31T08:04:58.918810Z",
-     "shell.execute_reply": "2022-03-31T08:04:58.918360Z"
+     "iopub.execute_input": "2022-04-22T12:44:08.023515Z",
+     "iopub.status.busy": "2022-04-22T12:44:08.022996Z",
+     "iopub.status.idle": "2022-04-22T12:44:08.030775Z",
+     "shell.execute_reply": "2022-04-22T12:44:08.029621Z"
     },
     "papermill": {
-     "duration": 0.037389,
-     "end_time": "2022-03-31T08:04:58.921559",
+     "duration": 0.098135,
+     "end_time": "2022-04-22T12:44:08.038803",
      "exception": false,
-     "start_time": "2022-03-31T08:04:58.884170",
+     "start_time": "2022-04-22T12:44:07.940668",
      "status": "completed"
     },
     "tags": []
@@ -940,10 +909,10 @@
    "id": "fe503149-8950-4319-8d78-3d178fd6f200",
    "metadata": {
     "papermill": {
-     "duration": 0.040051,
-     "end_time": "2022-03-31T08:04:58.993408",
+     "duration": 0.080219,
+     "end_time": "2022-04-22T12:44:08.202697",
      "exception": false,
-     "start_time": "2022-03-31T08:04:58.953357",
+     "start_time": "2022-04-22T12:44:08.122478",
      "status": "completed"
     },
     "tags": []
@@ -958,16 +927,16 @@
    "id": "4e8e8ce9-4b90-43de-9ae7-12bb935bcb20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:04:59.058256Z",
-     "iopub.status.busy": "2022-03-31T08:04:59.058040Z",
-     "iopub.status.idle": "2022-03-31T08:04:59.060758Z",
-     "shell.execute_reply": "2022-03-31T08:04:59.060283Z"
+     "iopub.execute_input": "2022-04-22T12:44:08.371976Z",
+     "iopub.status.busy": "2022-04-22T12:44:08.371473Z",
+     "iopub.status.idle": "2022-04-22T12:44:08.377379Z",
+     "shell.execute_reply": "2022-04-22T12:44:08.376179Z"
     },
     "papermill": {
-     "duration": 0.037632,
-     "end_time": "2022-03-31T08:04:59.062968",
+     "duration": 0.096743,
+     "end_time": "2022-04-22T12:44:08.384175",
      "exception": false,
-     "start_time": "2022-03-31T08:04:59.025336",
+     "start_time": "2022-04-22T12:44:08.287432",
      "status": "completed"
     },
     "tags": []
@@ -983,16 +952,16 @@
    "id": "53fd6089-158d-4682-a4f6-2b411d1140f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:04:59.128558Z",
-     "iopub.status.busy": "2022-03-31T08:04:59.128355Z",
-     "iopub.status.idle": "2022-03-31T08:04:59.132092Z",
-     "shell.execute_reply": "2022-03-31T08:04:59.131575Z"
+     "iopub.execute_input": "2022-04-22T12:44:08.553799Z",
+     "iopub.status.busy": "2022-04-22T12:44:08.553267Z",
+     "iopub.status.idle": "2022-04-22T12:44:08.562016Z",
+     "shell.execute_reply": "2022-04-22T12:44:08.560801Z"
     },
     "papermill": {
-     "duration": 0.038872,
-     "end_time": "2022-03-31T08:04:59.134275",
+     "duration": 0.099945,
+     "end_time": "2022-04-22T12:44:08.568313",
      "exception": false,
-     "start_time": "2022-03-31T08:04:59.095403",
+     "start_time": "2022-04-22T12:44:08.468368",
      "status": "completed"
     },
     "tags": []
@@ -1012,16 +981,16 @@
    "id": "e81e540e-b6d2-48b7-ae97-ff15dcc8d394",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:04:59.198083Z",
-     "iopub.status.busy": "2022-03-31T08:04:59.197852Z",
-     "iopub.status.idle": "2022-03-31T08:04:59.201410Z",
-     "shell.execute_reply": "2022-03-31T08:04:59.200982Z"
+     "iopub.execute_input": "2022-04-22T12:44:08.737052Z",
+     "iopub.status.busy": "2022-04-22T12:44:08.736559Z",
+     "iopub.status.idle": "2022-04-22T12:44:08.743550Z",
+     "shell.execute_reply": "2022-04-22T12:44:08.742390Z"
     },
     "papermill": {
-     "duration": 0.037703,
-     "end_time": "2022-03-31T08:04:59.203413",
+     "duration": 0.0975,
+     "end_time": "2022-04-22T12:44:08.750061",
      "exception": false,
-     "start_time": "2022-03-31T08:04:59.165710",
+     "start_time": "2022-04-22T12:44:08.652561",
      "status": "completed"
     },
     "tags": []
@@ -1040,16 +1009,16 @@
    "id": "42b85a04-1d97-41af-af7d-9647645cc5c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:04:59.266842Z",
-     "iopub.status.busy": "2022-03-31T08:04:59.266642Z",
-     "iopub.status.idle": "2022-03-31T08:07:35.750300Z",
-     "shell.execute_reply": "2022-03-31T08:07:35.749533Z"
+     "iopub.execute_input": "2022-04-22T12:44:08.919949Z",
+     "iopub.status.busy": "2022-04-22T12:44:08.919453Z",
+     "iopub.status.idle": "2022-04-22T12:48:14.312186Z",
+     "shell.execute_reply": "2022-04-22T12:48:14.310828Z"
     },
     "papermill": {
-     "duration": 156.516801,
-     "end_time": "2022-03-31T08:07:35.751996",
+     "duration": 245.482475,
+     "end_time": "2022-04-22T12:48:14.316530",
      "exception": false,
-     "start_time": "2022-03-31T08:04:59.235195",
+     "start_time": "2022-04-22T12:44:08.834055",
      "status": "completed"
     },
     "tags": []
@@ -1059,7 +1028,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Converted file: /scratch/lsftmp/6152749.tmpdir/tmp_n1sbprn.mae\n"
+      "Converted file: /scratch/lsftmp/6525607.tmpdir/tmp195pmphc.mae\n"
      ]
     },
     {
@@ -1073,7 +1042,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JobId: lt10-0-624560bd\n",
+      "JobId: lu04-0-6262a33d\n",
       "ExitStatus: finished\n"
      ]
     },
@@ -1106,10 +1075,10 @@
    "id": "f12885ea-b91f-473e-882a-08ddcb99d60f",
    "metadata": {
     "papermill": {
-     "duration": 0.033839,
-     "end_time": "2022-03-31T08:07:35.821239",
+     "duration": 0.092619,
+     "end_time": "2022-04-22T12:48:14.513581",
      "exception": false,
-     "start_time": "2022-03-31T08:07:35.787400",
+     "start_time": "2022-04-22T12:48:14.420962",
      "status": "completed"
     },
     "tags": []
@@ -1131,16 +1100,16 @@
    "id": "9d84eacd-3b8e-49d4-b1f3-c106735a6460",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:35.889055Z",
-     "iopub.status.busy": "2022-03-31T08:07:35.888834Z",
-     "iopub.status.idle": "2022-03-31T08:07:35.892200Z",
-     "shell.execute_reply": "2022-03-31T08:07:35.891740Z"
+     "iopub.execute_input": "2022-04-22T12:48:14.700495Z",
+     "iopub.status.busy": "2022-04-22T12:48:14.700013Z",
+     "iopub.status.idle": "2022-04-22T12:48:14.707771Z",
+     "shell.execute_reply": "2022-04-22T12:48:14.706234Z"
     },
     "papermill": {
-     "duration": 0.040676,
-     "end_time": "2022-03-31T08:07:35.895132",
+     "duration": 0.11713,
+     "end_time": "2022-04-22T12:48:14.722962",
      "exception": false,
-     "start_time": "2022-03-31T08:07:35.854456",
+     "start_time": "2022-04-22T12:48:14.605832",
      "status": "completed"
     },
     "tags": []
@@ -1192,10 +1161,10 @@
    "id": "163bef90-207c-4023-b494-6847af3f4958",
    "metadata": {
     "papermill": {
-     "duration": 0.032626,
-     "end_time": "2022-03-31T08:07:35.961803",
+     "duration": 0.091465,
+     "end_time": "2022-04-22T12:48:14.910458",
      "exception": false,
-     "start_time": "2022-03-31T08:07:35.929177",
+     "start_time": "2022-04-22T12:48:14.818993",
      "status": "completed"
     },
     "tags": []
@@ -1210,16 +1179,16 @@
    "id": "372d7ea1-324a-4f44-8b8d-3cc3021d2c81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:36.028255Z",
-     "iopub.status.busy": "2022-03-31T08:07:36.028054Z",
-     "iopub.status.idle": "2022-03-31T08:07:36.030902Z",
-     "shell.execute_reply": "2022-03-31T08:07:36.030425Z"
+     "iopub.execute_input": "2022-04-22T12:48:15.097746Z",
+     "iopub.status.busy": "2022-04-22T12:48:15.096823Z",
+     "iopub.status.idle": "2022-04-22T12:48:15.107376Z",
+     "shell.execute_reply": "2022-04-22T12:48:15.105388Z"
     },
     "papermill": {
-     "duration": 0.038967,
-     "end_time": "2022-03-31T08:07:36.033061",
+     "duration": 0.112501,
+     "end_time": "2022-04-22T12:48:15.115150",
      "exception": false,
-     "start_time": "2022-03-31T08:07:35.994094",
+     "start_time": "2022-04-22T12:48:15.002649",
      "status": "completed"
     },
     "tags": []
@@ -1235,16 +1204,16 @@
    "id": "83002b9e-0eb8-4f39-8d55-2cbb3b55d7a4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:36.099819Z",
-     "iopub.status.busy": "2022-03-31T08:07:36.099564Z",
-     "iopub.status.idle": "2022-03-31T08:07:36.103131Z",
-     "shell.execute_reply": "2022-03-31T08:07:36.102665Z"
+     "iopub.execute_input": "2022-04-22T12:48:15.306139Z",
+     "iopub.status.busy": "2022-04-22T12:48:15.305554Z",
+     "iopub.status.idle": "2022-04-22T12:48:15.314882Z",
+     "shell.execute_reply": "2022-04-22T12:48:15.313611Z"
     },
     "papermill": {
-     "duration": 0.039451,
-     "end_time": "2022-03-31T08:07:36.105532",
+     "duration": 0.112318,
+     "end_time": "2022-04-22T12:48:15.322503",
      "exception": false,
-     "start_time": "2022-03-31T08:07:36.066081",
+     "start_time": "2022-04-22T12:48:15.210185",
      "status": "completed"
     },
     "tags": []
@@ -1263,16 +1232,16 @@
    "id": "cac30a83-1546-4abd-9186-d951a2d52a8c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:36.173758Z",
-     "iopub.status.busy": "2022-03-31T08:07:36.173541Z",
-     "iopub.status.idle": "2022-03-31T08:07:36.176484Z",
-     "shell.execute_reply": "2022-03-31T08:07:36.176036Z"
+     "iopub.execute_input": "2022-04-22T12:48:15.509034Z",
+     "iopub.status.busy": "2022-04-22T12:48:15.508490Z",
+     "iopub.status.idle": "2022-04-22T12:48:15.515625Z",
+     "shell.execute_reply": "2022-04-22T12:48:15.514369Z"
     },
     "papermill": {
-     "duration": 0.040239,
-     "end_time": "2022-03-31T08:07:36.178750",
+     "duration": 0.114755,
+     "end_time": "2022-04-22T12:48:15.527140",
      "exception": false,
-     "start_time": "2022-03-31T08:07:36.138511",
+     "start_time": "2022-04-22T12:48:15.412385",
      "status": "completed"
     },
     "tags": []
@@ -1288,16 +1257,16 @@
    "id": "edcd8461-6b23-4e39-9800-e7755c640a45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:36.246632Z",
-     "iopub.status.busy": "2022-03-31T08:07:36.246398Z",
-     "iopub.status.idle": "2022-03-31T08:07:43.420000Z",
-     "shell.execute_reply": "2022-03-31T08:07:43.419268Z"
+     "iopub.execute_input": "2022-04-22T12:48:15.706569Z",
+     "iopub.status.busy": "2022-04-22T12:48:15.706036Z",
+     "iopub.status.idle": "2022-04-22T12:48:28.255865Z",
+     "shell.execute_reply": "2022-04-22T12:48:28.254307Z"
     },
     "papermill": {
-     "duration": 7.209052,
-     "end_time": "2022-03-31T08:07:43.421910",
+     "duration": 12.650388,
+     "end_time": "2022-04-22T12:48:28.260543",
      "exception": false,
-     "start_time": "2022-03-31T08:07:36.212858",
+     "start_time": "2022-04-22T12:48:15.610155",
      "status": "completed"
     },
     "tags": []
@@ -1317,7 +1286,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7.17 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+      "12.5 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
      ]
     }
    ],
@@ -1333,10 +1302,10 @@
    "id": "be0b03ee-6123-4077-b3fd-586bce4bf748",
    "metadata": {
     "papermill": {
-     "duration": 0.04168,
-     "end_time": "2022-03-31T08:07:43.508955",
+     "duration": 0.09428,
+     "end_time": "2022-04-22T12:48:28.450651",
      "exception": false,
-     "start_time": "2022-03-31T08:07:43.467275",
+     "start_time": "2022-04-22T12:48:28.356371",
      "status": "completed"
     },
     "tags": []
@@ -1351,16 +1320,16 @@
    "id": "0c7dcbf1-7607-4b5f-8ed4-44f0a00b41e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:43.591609Z",
-     "iopub.status.busy": "2022-03-31T08:07:43.591388Z",
-     "iopub.status.idle": "2022-03-31T08:07:43.594657Z",
-     "shell.execute_reply": "2022-03-31T08:07:43.594209Z"
+     "iopub.execute_input": "2022-04-22T12:48:28.637022Z",
+     "iopub.status.busy": "2022-04-22T12:48:28.636470Z",
+     "iopub.status.idle": "2022-04-22T12:48:28.644342Z",
+     "shell.execute_reply": "2022-04-22T12:48:28.643210Z"
     },
     "papermill": {
-     "duration": 0.045168,
-     "end_time": "2022-03-31T08:07:43.596870",
+     "duration": 0.111127,
+     "end_time": "2022-04-22T12:48:28.651027",
      "exception": false,
-     "start_time": "2022-03-31T08:07:43.551702",
+     "start_time": "2022-04-22T12:48:28.539900",
      "status": "completed"
     },
     "tags": []
@@ -1376,16 +1345,16 @@
    "id": "61322085-91dd-47b6-9517-33383a7d5a5c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:43.660880Z",
-     "iopub.status.busy": "2022-03-31T08:07:43.660681Z",
-     "iopub.status.idle": "2022-03-31T08:07:46.203073Z",
-     "shell.execute_reply": "2022-03-31T08:07:46.202278Z"
+     "iopub.execute_input": "2022-04-22T12:48:28.845504Z",
+     "iopub.status.busy": "2022-04-22T12:48:28.845038Z",
+     "iopub.status.idle": "2022-04-22T12:48:35.771910Z",
+     "shell.execute_reply": "2022-04-22T12:48:35.770052Z"
     },
     "papermill": {
-     "duration": 2.576451,
-     "end_time": "2022-03-31T08:07:46.204766",
+     "duration": 7.030486,
+     "end_time": "2022-04-22T12:48:35.777474",
      "exception": false,
-     "start_time": "2022-03-31T08:07:43.628315",
+     "start_time": "2022-04-22T12:48:28.746988",
      "status": "completed"
     },
     "tags": []
@@ -1405,7 +1374,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.54 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+      "6.91 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
      ]
     }
    ],
@@ -1421,10 +1390,10 @@
    "id": "af8fc96b-3dae-4fcf-bf50-693df0fa9be8",
    "metadata": {
     "papermill": {
-     "duration": 0.033196,
-     "end_time": "2022-03-31T08:07:46.274042",
+     "duration": 0.109259,
+     "end_time": "2022-04-22T12:48:35.999854",
      "exception": false,
-     "start_time": "2022-03-31T08:07:46.240846",
+     "start_time": "2022-04-22T12:48:35.890595",
      "status": "completed"
     },
     "tags": []
@@ -1439,16 +1408,16 @@
    "id": "f052e537-e0ab-4ba2-9549-40b809ea112f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:46.341790Z",
-     "iopub.status.busy": "2022-03-31T08:07:46.341551Z",
-     "iopub.status.idle": "2022-03-31T08:07:46.344808Z",
-     "shell.execute_reply": "2022-03-31T08:07:46.344354Z"
+     "iopub.execute_input": "2022-04-22T12:48:36.214398Z",
+     "iopub.status.busy": "2022-04-22T12:48:36.214006Z",
+     "iopub.status.idle": "2022-04-22T12:48:36.220133Z",
+     "shell.execute_reply": "2022-04-22T12:48:36.218938Z"
     },
     "papermill": {
-     "duration": 0.039599,
-     "end_time": "2022-03-31T08:07:46.346983",
+     "duration": 0.117177,
+     "end_time": "2022-04-22T12:48:36.225641",
      "exception": false,
-     "start_time": "2022-03-31T08:07:46.307384",
+     "start_time": "2022-04-22T12:48:36.108464",
      "status": "completed"
     },
     "tags": []
@@ -1464,16 +1433,16 @@
    "id": "350ebff7-9fe2-4f12-9ec1-5cb65b8848d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:07:46.415247Z",
-     "iopub.status.busy": "2022-03-31T08:07:46.415049Z",
-     "iopub.status.idle": "2022-03-31T08:08:14.176967Z",
-     "shell.execute_reply": "2022-03-31T08:08:14.176452Z"
+     "iopub.execute_input": "2022-04-22T12:48:36.413598Z",
+     "iopub.status.busy": "2022-04-22T12:48:36.413122Z",
+     "iopub.status.idle": "2022-04-22T12:49:13.177974Z",
+     "shell.execute_reply": "2022-04-22T12:49:13.176657Z"
     },
     "papermill": {
-     "duration": 27.798336,
-     "end_time": "2022-03-31T08:08:14.178555",
+     "duration": 36.934558,
+     "end_time": "2022-04-22T12:49:13.237887",
      "exception": false,
-     "start_time": "2022-03-31T08:07:46.380219",
+     "start_time": "2022-04-22T12:48:36.303329",
      "status": "completed"
     },
     "tags": []
@@ -1498,7 +1467,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JobId: lt10-0-62456159\n"
+      "JobId: lu04-0-6262a42c\n"
      ]
     },
     {
@@ -1515,7 +1484,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "27.8 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
+      "36.7 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)\n"
      ]
     }
    ],
@@ -1531,10 +1500,10 @@
    "id": "8a071c6c-0ac7-4ddd-8222-2dc286422504",
    "metadata": {
     "papermill": {
-     "duration": 0.0354,
-     "end_time": "2022-03-31T08:08:14.256047",
+     "duration": 0.070175,
+     "end_time": "2022-04-22T12:49:13.378873",
      "exception": false,
-     "start_time": "2022-03-31T08:08:14.220647",
+     "start_time": "2022-04-22T12:49:13.308698",
      "status": "completed"
     },
     "tags": []
@@ -1548,10 +1517,10 @@
    "id": "6d6e7776-604e-4072-bffd-89aaef4bd034",
    "metadata": {
     "papermill": {
-     "duration": 0.034191,
-     "end_time": "2022-03-31T08:08:14.326016",
+     "duration": 0.075498,
+     "end_time": "2022-04-22T12:49:13.525566",
      "exception": false,
-     "start_time": "2022-03-31T08:08:14.291825",
+     "start_time": "2022-04-22T12:49:13.450068",
      "status": "completed"
     },
     "tags": []
@@ -1568,16 +1537,16 @@
    "id": "836af6ba-0207-43ed-890d-e2f863dce352",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:08:14.394138Z",
-     "iopub.status.busy": "2022-03-31T08:08:14.393897Z",
-     "iopub.status.idle": "2022-03-31T08:08:14.396747Z",
-     "shell.execute_reply": "2022-03-31T08:08:14.396227Z"
+     "iopub.execute_input": "2022-04-22T12:49:13.676030Z",
+     "iopub.status.busy": "2022-04-22T12:49:13.675636Z",
+     "iopub.status.idle": "2022-04-22T12:49:13.680713Z",
+     "shell.execute_reply": "2022-04-22T12:49:13.679784Z"
     },
     "papermill": {
-     "duration": 0.038934,
-     "end_time": "2022-03-31T08:08:14.398928",
+     "duration": 0.085693,
+     "end_time": "2022-04-22T12:49:13.686294",
      "exception": false,
-     "start_time": "2022-03-31T08:08:14.359994",
+     "start_time": "2022-04-22T12:49:13.600601",
      "status": "completed"
     },
     "tags": []
@@ -1593,16 +1562,16 @@
    "id": "ffc06935-e0ae-4a73-bf7d-4ff0669eebe9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:08:14.466460Z",
-     "iopub.status.busy": "2022-03-31T08:08:14.466261Z",
-     "iopub.status.idle": "2022-03-31T08:08:14.469797Z",
-     "shell.execute_reply": "2022-03-31T08:08:14.469364Z"
+     "iopub.execute_input": "2022-04-22T12:49:13.836671Z",
+     "iopub.status.busy": "2022-04-22T12:49:13.836303Z",
+     "iopub.status.idle": "2022-04-22T12:49:13.843030Z",
+     "shell.execute_reply": "2022-04-22T12:49:13.842117Z"
     },
     "papermill": {
-     "duration": 0.03973,
-     "end_time": "2022-03-31T08:08:14.471913",
+     "duration": 0.086812,
+     "end_time": "2022-04-22T12:49:13.848122",
      "exception": false,
-     "start_time": "2022-03-31T08:08:14.432183",
+     "start_time": "2022-04-22T12:49:13.761310",
      "status": "completed"
     },
     "tags": []
@@ -1621,16 +1590,16 @@
    "id": "aad92cea-d047-40e3-b194-92c3130a3223",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:08:14.539634Z",
-     "iopub.status.busy": "2022-03-31T08:08:14.539425Z",
-     "iopub.status.idle": "2022-03-31T08:08:14.543299Z",
-     "shell.execute_reply": "2022-03-31T08:08:14.542876Z"
+     "iopub.execute_input": "2022-04-22T12:49:13.994697Z",
+     "iopub.status.busy": "2022-04-22T12:49:13.994319Z",
+     "iopub.status.idle": "2022-04-22T12:49:14.000894Z",
+     "shell.execute_reply": "2022-04-22T12:49:13.999895Z"
     },
     "papermill": {
-     "duration": 0.039632,
-     "end_time": "2022-03-31T08:08:14.545106",
+     "duration": 0.084522,
+     "end_time": "2022-04-22T12:49:14.005754",
      "exception": false,
-     "start_time": "2022-03-31T08:08:14.505474",
+     "start_time": "2022-04-22T12:49:13.921232",
      "status": "completed"
     },
     "tags": []
@@ -1649,16 +1618,16 @@
    "id": "6b2776cb-774d-4255-b299-7c56ccec611a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:08:14.616701Z",
-     "iopub.status.busy": "2022-03-31T08:08:14.616446Z",
-     "iopub.status.idle": "2022-03-31T08:16:28.203211Z",
-     "shell.execute_reply": "2022-03-31T08:16:28.202696Z"
+     "iopub.execute_input": "2022-04-22T12:49:14.180826Z",
+     "iopub.status.busy": "2022-04-22T12:49:14.180303Z",
+     "iopub.status.idle": "2022-04-22T12:53:25.625018Z",
+     "shell.execute_reply": "2022-04-22T12:53:25.623299Z"
     },
     "papermill": {
-     "duration": 493.626875,
-     "end_time": "2022-03-31T08:16:28.204845",
+     "duration": 251.550071,
+     "end_time": "2022-04-22T12:53:25.628872",
      "exception": false,
-     "start_time": "2022-03-31T08:08:14.577970",
+     "start_time": "2022-04-22T12:49:14.078801",
      "status": "completed"
     },
     "tags": []
@@ -1668,14 +1637,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JobId: lt10-0-62456191\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Converted file: /scratch/lsftmp/6152749.tmpdir/tmpg0s9ghna.mae\n"
+      "Converted file: /scratch/lsftmp/6525607.tmpdir/tmp5xoq3zd9.mae\n"
      ]
     },
     {
@@ -1689,22 +1651,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JobId: lt10-0-6245628f\n",
-      "ExitStatus: finished\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Removing previous job files...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JobId: lt10-0-624562d1\n",
+      "JobId: lu04-0-6262a474\n",
       "ExitStatus: finished\n"
      ]
     },
@@ -1738,16 +1685,16 @@
    "id": "36b3c973-9931-4442-945b-e339dab3f1c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:16:28.288799Z",
-     "iopub.status.busy": "2022-03-31T08:16:28.288568Z",
-     "iopub.status.idle": "2022-03-31T08:16:28.292690Z",
-     "shell.execute_reply": "2022-03-31T08:16:28.292219Z"
+     "iopub.execute_input": "2022-04-22T12:53:25.858694Z",
+     "iopub.status.busy": "2022-04-22T12:53:25.858145Z",
+     "iopub.status.idle": "2022-04-22T12:53:25.869178Z",
+     "shell.execute_reply": "2022-04-22T12:53:25.867157Z"
     },
     "papermill": {
-     "duration": 0.045542,
-     "end_time": "2022-03-31T08:16:28.295737",
+     "duration": 0.141015,
+     "end_time": "2022-04-22T12:53:25.881014",
      "exception": false,
-     "start_time": "2022-03-31T08:16:28.250195",
+     "start_time": "2022-04-22T12:53:25.739999",
      "status": "completed"
     },
     "tags": []
@@ -1774,10 +1721,10 @@
    "id": "77db9232-360d-40ee-8b2f-640eaf6bdc1a",
    "metadata": {
     "papermill": {
-     "duration": 0.038136,
-     "end_time": "2022-03-31T08:16:28.371350",
+     "duration": 0.118895,
+     "end_time": "2022-04-22T12:53:26.116629",
      "exception": false,
-     "start_time": "2022-03-31T08:16:28.333214",
+     "start_time": "2022-04-22T12:53:25.997734",
      "status": "completed"
     },
     "tags": []
@@ -1794,16 +1741,16 @@
    "id": "f680e950-d0e2-43ce-9bad-2da70a94bde5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:16:28.448505Z",
-     "iopub.status.busy": "2022-03-31T08:16:28.448293Z",
-     "iopub.status.idle": "2022-03-31T08:16:28.451511Z",
-     "shell.execute_reply": "2022-03-31T08:16:28.451046Z"
+     "iopub.execute_input": "2022-04-22T12:53:26.316324Z",
+     "iopub.status.busy": "2022-04-22T12:53:26.315796Z",
+     "iopub.status.idle": "2022-04-22T12:53:26.323998Z",
+     "shell.execute_reply": "2022-04-22T12:53:26.322084Z"
     },
     "papermill": {
-     "duration": 0.045108,
-     "end_time": "2022-03-31T08:16:28.454503",
+     "duration": 0.142074,
+     "end_time": "2022-04-22T12:53:26.335796",
      "exception": false,
-     "start_time": "2022-03-31T08:16:28.409395",
+     "start_time": "2022-04-22T12:53:26.193722",
      "status": "completed"
     },
     "tags": []
@@ -1849,16 +1796,16 @@
    "id": "e14082da-b8f1-477a-8bcd-810936e07e72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:16:28.531832Z",
-     "iopub.status.busy": "2022-03-31T08:16:28.531614Z",
-     "iopub.status.idle": "2022-03-31T08:16:28.534351Z",
-     "shell.execute_reply": "2022-03-31T08:16:28.533880Z"
+     "iopub.execute_input": "2022-04-22T12:53:26.498935Z",
+     "iopub.status.busy": "2022-04-22T12:53:26.498655Z",
+     "iopub.status.idle": "2022-04-22T12:53:26.502381Z",
+     "shell.execute_reply": "2022-04-22T12:53:26.501621Z"
     },
     "papermill": {
-     "duration": 0.044445,
-     "end_time": "2022-03-31T08:16:28.536653",
+     "duration": 0.051614,
+     "end_time": "2022-04-22T12:53:26.506129",
      "exception": false,
-     "start_time": "2022-03-31T08:16:28.492208",
+     "start_time": "2022-04-22T12:53:26.454515",
      "status": "completed"
     },
     "tags": []
@@ -1874,16 +1821,16 @@
    "id": "f558ef87-b33e-4bd1-a474-b13e90e69195",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:16:28.613943Z",
-     "iopub.status.busy": "2022-03-31T08:16:28.613733Z",
-     "iopub.status.idle": "2022-03-31T08:16:28.617325Z",
-     "shell.execute_reply": "2022-03-31T08:16:28.616854Z"
+     "iopub.execute_input": "2022-04-22T12:53:26.641764Z",
+     "iopub.status.busy": "2022-04-22T12:53:26.641485Z",
+     "iopub.status.idle": "2022-04-22T12:53:26.646318Z",
+     "shell.execute_reply": "2022-04-22T12:53:26.645636Z"
     },
     "papermill": {
-     "duration": 0.044873,
-     "end_time": "2022-03-31T08:16:28.619656",
+     "duration": 0.101318,
+     "end_time": "2022-04-22T12:53:26.649838",
      "exception": false,
-     "start_time": "2022-03-31T08:16:28.574783",
+     "start_time": "2022-04-22T12:53:26.548520",
      "status": "completed"
     },
     "tags": []
@@ -1902,16 +1849,16 @@
    "id": "b7fcc40c-b3f3-4451-9f8d-501f27328f32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:16:28.696866Z",
-     "iopub.status.busy": "2022-03-31T08:16:28.696654Z",
-     "iopub.status.idle": "2022-03-31T08:16:28.699617Z",
-     "shell.execute_reply": "2022-03-31T08:16:28.699146Z"
+     "iopub.execute_input": "2022-04-22T12:53:26.809639Z",
+     "iopub.status.busy": "2022-04-22T12:53:26.809016Z",
+     "iopub.status.idle": "2022-04-22T12:53:26.817480Z",
+     "shell.execute_reply": "2022-04-22T12:53:26.816124Z"
     },
     "papermill": {
-     "duration": 0.044263,
-     "end_time": "2022-03-31T08:16:28.701922",
+     "duration": 0.133854,
+     "end_time": "2022-04-22T12:53:26.827113",
      "exception": false,
-     "start_time": "2022-03-31T08:16:28.657659",
+     "start_time": "2022-04-22T12:53:26.693259",
      "status": "completed"
     },
     "tags": []
@@ -1929,16 +1876,16 @@
    "id": "7a7489c6-d564-4285-b5d6-b8cb510d68f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:16:28.779560Z",
-     "iopub.status.busy": "2022-03-31T08:16:28.779352Z",
-     "iopub.status.idle": "2022-03-31T08:19:38.453180Z",
-     "shell.execute_reply": "2022-03-31T08:19:38.452409Z"
+     "iopub.execute_input": "2022-04-22T12:53:26.923066Z",
+     "iopub.status.busy": "2022-04-22T12:53:26.922585Z",
+     "iopub.status.idle": "2022-04-22T12:57:20.443875Z",
+     "shell.execute_reply": "2022-04-22T12:57:20.443023Z"
     },
     "papermill": {
-     "duration": 189.74411,
-     "end_time": "2022-03-31T08:19:38.484596",
+     "duration": 233.591896,
+     "end_time": "2022-04-22T12:57:20.470472",
      "exception": false,
-     "start_time": "2022-03-31T08:16:28.740486",
+     "start_time": "2022-04-22T12:53:26.878576",
      "status": "completed"
     },
     "tags": []
@@ -1967,16 +1914,16 @@
    "id": "ed84f951-689a-4d8d-b2b9-c5eda645f624",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-03-31T08:19:38.564804Z",
-     "iopub.status.busy": "2022-03-31T08:19:38.564560Z",
-     "iopub.status.idle": "2022-03-31T08:19:38.613485Z",
-     "shell.execute_reply": "2022-03-31T08:19:38.612965Z"
+     "iopub.execute_input": "2022-04-22T12:57:20.676917Z",
+     "iopub.status.busy": "2022-04-22T12:57:20.676448Z",
+     "iopub.status.idle": "2022-04-22T12:57:20.726850Z",
+     "shell.execute_reply": "2022-04-22T12:57:20.725753Z"
     },
     "papermill": {
-     "duration": 0.091515,
-     "end_time": "2022-03-31T08:19:38.615650",
+     "duration": 0.158403,
+     "end_time": "2022-04-22T12:57:20.730863",
      "exception": false,
-     "start_time": "2022-03-31T08:19:38.524135",
+     "start_time": "2022-04-22T12:57:20.572460",
      "status": "completed"
     },
     "tags": []
@@ -2125,14 +2072,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1694.734135,
-   "end_time": "2022-03-31T08:19:39.295614",
+   "duration": 1121.080541,
+   "end_time": "2022-04-22T12:57:22.293896",
    "environment_variables": {},
    "exception": null,
    "input_path": "Schrodinger_structural_featurizer.ipynb",
    "output_path": "Schrodinger_structural_featurizer_out.ipynb",
    "parameters": {},
-   "start_time": "2022-03-31T07:51:24.561479",
+   "start_time": "2022-04-22T12:38:41.213355",
    "version": "2.2.2"
   }
  },

--- a/examples/kinoml_object_model.ipynb
+++ b/examples/kinoml_object_model.ipynb
@@ -703,9 +703,7 @@
    "outputs": [],
    "source": [
     "from kinoml.datasets.chembl import ChEMBLDatasetProvider\n",
-    "from kinoml.datasets.pkis2 import PKIS2DatasetProvider\n",
-    "\n",
-    "from kinoml.core.proteins import Protein"
+    "from kinoml.datasets.pkis2 import PKIS2DatasetProvider"
    ]
   },
   {
@@ -715,20 +713,17 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "<PKIS2DatasetProvider with 261870 PercentageDisplacementMeasurement measurements and 261870 systems (Ligand=640, KLIFSKinase=406)>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<PKIS2DatasetProvider with 261870 PercentageDisplacementMeasurement measurements and 261870 systems (Ligand=640, KLIFSKinase=406)>\n"
+     ]
     }
    ],
    "source": [
     "# load data points given by the PKIS2 publication (https://doi.org/10.1371/journal.pone.0181585)\n",
     "pkis2 = PKIS2DatasetProvider.from_source()\n",
-    "pkis2"
+    "print(pkis2)"
    ]
   },
   {
@@ -740,7 +735,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "60e6891200ac4d9cb6805e400b72eda2",
+       "model_id": "b89a3b1bc95047658f2c635c58b233ba",
        "version_major": 2,
        "version_minor": 0
       },
@@ -765,11 +760,12 @@
    "source": [
     "# load curated ChEMBL data points available at https://github.com/openkinome/kinodata\n",
     "# here the more general \"Protein\" object will be used instead of the default \"KLIFSKinase\"\n",
+    "# also protein objects will be initialized with the MDAnalysis toolkit\n",
     "chembl = ChEMBLDatasetProvider.from_source(\n",
     "    path_or_url=\"https://github.com/openkinome/datascripts/releases/download/v0.3/activities-chembl29_v0.3.zip\",\n",
     "    measurement_types=(\"pIC50\", \"pKi\", \"pKd\"),\n",
-    "    sample=None,\n",
-    "    protein_type=Protein,\n",
+    "    protein_type=\"Protein\",\n",
+    "    toolkit=\"MDAnalysis\",\n",
     ")\n",
     "chembl"
    ]
@@ -783,7 +779,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5de0cf09e3f441148bd0a5f1120d4686",
+       "model_id": "4f8e922d72ca4f5886727d3da11b372e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -797,7 +793,7 @@
     {
      "data": {
       "text/plain": [
-       "<ChEMBLDatasetProvider with 100 measurements (pKiMeasurement=100), and 100 systems (KLIFSKinase=36, Ligand=99)>"
+       "<ChEMBLDatasetProvider with 100 measurements (pKiMeasurement=100), and 100 systems (KLIFSKinase=38, Ligand=100)>"
       ]
      },
      "execution_count": 26,
@@ -825,7 +821,7 @@
     {
      "data": {
       "text/plain": [
-       "<ChEMBLDatasetProvider with 100 measurements (pKiMeasurement=100), and 100 systems (KLIFSKinase=36, Ligand=99)>"
+       "<ChEMBLDatasetProvider with 100 measurements (pKiMeasurement=100), and 100 systems (KLIFSKinase=38, Ligand=100)>"
       ]
      },
      "execution_count": 27,
@@ -861,13 +857,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "There were 4 systems that could not be featurized!\n"
+      "There were 3 systems that could not be featurized!\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<ChEMBLDatasetProvider with 96 measurements (pKiMeasurement=96), and 96 systems (KLIFSKinase=35, Ligand=95)>"
+       "<ChEMBLDatasetProvider with 97 measurements (pKiMeasurement=97), and 97 systems (KLIFSKinase=37, Ligand=97)>"
       ]
      },
      "execution_count": 29,

--- a/kinoml/features/complexes.py
+++ b/kinoml/features/complexes.py
@@ -1125,10 +1125,15 @@ class OEComplexFeaturizer(OEBaseModelingFeaturizer, SingleLigandProteinComplexFe
     Given systems with exactly one protein and one ligand, prepare the complex
     structure by:
 
-     - modeling missing loops
+     - modeling missing loops with OESpruce according to the PDB header unless
+       a custom sequence is specified via the `uniprot_id` or `sequence`
+       attribute in the protein component (see below), missing sequences at
+       N- and C-termini are not modeled
      - building missing side chains
-     - mutations, if `uniprot_id` or `sequence` attribute is provided for the
-       protein component (see below)
+     - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`
+       attribute is provided for the protein component alteration will be
+       modeled with OESpruce, if an alteration could not be modeled, the
+       corresponding mismatch in the structure will be deleted
      - removing everything but protein, water and ligand of interest
      - protonation at pH 7.4
 
@@ -1298,10 +1303,15 @@ class OEDockingFeaturizer(OEBaseModelingFeaturizer, SingleLigandProteinComplexFe
     structure and dock the ligand into the prepared protein structure with
     one of OpenEye's docking algorithms:
 
-     - modeling missing loops
+     - modeling missing loops with OESpruce according to the PDB header unless
+       a custom sequence is specified via the `uniprot_id` or `sequence`
+       attribute in the protein component (see below), missing sequences at
+       N- and C-termini are not modeled
      - building missing side chains
-     - mutations, if `uniprot_id` or `sequence` attribute is provided for the
-       protein component (see below)
+     - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`
+       attribute is provided for the protein component alteration will be
+       modeled with OESpruce, if an alteration could not be modeled, the
+       corresponding mismatch in the structure will be deleted
      - removing everything but protein, water and ligand of interest
      - protonation at pH 7.4
      - perform docking
@@ -1573,6 +1583,18 @@ class SCHRODINGERComplexFeaturizer(SingleLigandProteinComplexFeaturizer):
     """
     Given systems with exactly one protein and one ligand, prepare the complex
     structure by:
+
+     - modeling missing loops with Prime according to the PDB header unless
+       a custom sequence is specified via the `uniprot_id` or `sequence`
+       attribute in the protein component (see below), missing sequences at
+       N- and C-termini are not modeled
+     - building missing side chains
+     - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`
+       attribute is provided for the protein component alteration will be first
+       deleted and subsequently the intended sequence modeled with Prime, if
+       an alteration could not be modeled, a corresponding deletion will remain
+     - removing everything but protein, water and ligand of interest
+     - protonation at pH 7.4
 
      - modeling missing loops
      - building missing side chains
@@ -2032,10 +2054,15 @@ class SCHRODINGERDockingFeaturizer(SCHRODINGERComplexFeaturizer):
     structure dock the ligand into its binding site identified by a
     co-crystallized ligand. The following steps will be performed:
 
-     - modeling missing loops
+     - modeling missing loops with Prime according to the PDB header unless
+       a custom sequence is specified via the `uniprot_id` or `sequence`
+       attribute in the protein component (see below), missing sequences at
+       N- and C-termini are not modeled
      - building missing side chains
-     - mutations, if `uniprot_id` or `sequence` attribute is provided for the
-       protein component (see below)
+     - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`
+       attribute is provided for the protein component alteration will be first
+       deleted and subsequently the intended sequence modeled with Prime, if
+       an alteration could not be modeled, a corresponding deletion will remain
      - removing everything but protein, water and ligand of interest
      - protonation at pH 7.4
      - docking a ligand

--- a/kinoml/features/complexes.py
+++ b/kinoml/features/complexes.py
@@ -1596,14 +1596,6 @@ class SCHRODINGERComplexFeaturizer(SingleLigandProteinComplexFeaturizer):
      - removing everything but protein, water and ligand of interest
      - protonation at pH 7.4
 
-     - modeling missing loops
-     - building missing side chains
-     - mutations, if `uniprot_id` or `sequence` attribute is provided for the
-       protein component
-       (see below)
-     - removing everything but protein, water and ligand of interest
-     - protonation at pH 7.4
-
     The protein component of each system must be a `core.proteins.Protein` or
     a subclass thereof, must be initialized with toolkit='MDAnalysis' and give
     access to the molecular structure, e.g. via a pdb_id. Additionally, the

--- a/kinoml/features/protein.py
+++ b/kinoml/features/protein.py
@@ -116,10 +116,15 @@ class OEProteinStructureFeaturizer(OEBaseModelingFeaturizer, SingleProteinFeatur
     """
     Given systems with exactly one protein, prepare the protein structure by:
 
-     - modeling missing loops
+     - modeling missing loops with OESpruce according to the PDB header unless
+       a custom sequence is specified via the `uniprot_id` or `sequence`
+       attribute in the protein component (see below), missing sequences at
+       N- and C-termini are not modeled
      - building missing side chains
-     - mutations, if `uniprot_id` or `sequence` attribute is provided for
-       the protein component (see below)
+     - substitutions, deletions and insertions, if a `uniprot_id` or `sequence`
+       attribute is provided for the protein component alteration will be
+       modeled with OESpruce, if an alteration could not be modeled, the
+       corresponding mismatch in the structure will be deleted
      - removing everything but protein and water
      - protonation at pH 7.4
 

--- a/kinoml/tests/datasets/test_chembl.py
+++ b/kinoml/tests/datasets/test_chembl.py
@@ -3,7 +3,8 @@ Test kinoml.datasets.core
 """
 
 
-def test_chembl():
+def test_chembl_protein_openeye():
+    from kinoml.core.proteins import Protein
     from kinoml.datasets.chembl import ChEMBLDatasetProvider
 
     # we will use a small subset with 100 entries only, for speed
@@ -11,5 +12,26 @@ def test_chembl():
         "https://github.com/openkinome/kinodata/releases/download/v0.3/activities-chembl29_v0.3.zip",
         uniprot_ids=["P00533"],
         sample=100,
+        protein_type="Protein",
+        toolkit="OpenEye",
     )
     assert len(chembl) == 100
+    assert isinstance(chembl.systems[0].protein, Protein)
+    assert chembl.systems[0].protein.toolkit == "OpenEye"
+
+
+def test_chembl_klifskinase_mdanalysis():
+    from kinoml.core.proteins import KLIFSKinase
+    from kinoml.datasets.chembl import ChEMBLDatasetProvider
+
+    # we will use a small subset with 100 entries only, for speed
+    chembl = ChEMBLDatasetProvider.from_source(
+        "https://github.com/openkinome/kinodata/releases/download/v0.3/activities-chembl29_v0.3.zip",
+        uniprot_ids=["P00533"],
+        sample=100,
+        protein_type="KLIFSKinase",
+        toolkit="MDAnalysis",
+    )
+    assert len(chembl) == 100
+    assert isinstance(chembl.systems[0].protein, KLIFSKinase)
+    assert chembl.systems[0].protein.toolkit == "MDAnalysis"

--- a/kinoml/tests/datasets/test_pkis2.py
+++ b/kinoml/tests/datasets/test_pkis2.py
@@ -3,10 +3,14 @@ Test kinoml.datasets.kinomescan
 """
 
 
-def test_pkis2():
+def test_pkis2_protein_openeye():
+    from kinoml.core.proteins import Protein
     from kinoml.datasets.pkis2 import PKIS2DatasetProvider
 
-    provider = PKIS2DatasetProvider.from_source()
+    provider = PKIS2DatasetProvider.from_source(
+        protein_type="Protein",
+        toolkit="OpenEye",
+    )
     assert len(provider.measurements) == 261_870
     assert (provider.measurements[0].values == 14.0).all()
     # check order in provider matches order in file
@@ -18,3 +22,28 @@ def test_pkis2():
         provider[17052].system.ligand.name
         == "CN(N=C1)C=C1C(C=C2)=NN3C2=NN=C3[C@@H](C)C4=CC=C(N=CC=C5)C5=C4"
     )
+    assert isinstance(provider.systems[0].protein, Protein)
+    assert provider.systems[0].protein.toolkit == "OpenEye"
+
+
+def test_pkis2_klifskinase_mdanalysis():
+    from kinoml.core.proteins import KLIFSKinase
+    from kinoml.datasets.pkis2 import PKIS2DatasetProvider
+
+    provider = PKIS2DatasetProvider.from_source(
+        protein_type="KLIFSKinase",
+        toolkit="MDAnalysis",
+    )
+    assert len(provider.measurements) == 261_870
+    assert (provider.measurements[0].values == 14.0).all()
+    # check order in provider matches order in file
+    assert (  # matches line 43 in file
+        provider[17051].system.ligand.name
+        == "O=C1NC(C2=C(C3=CC=CC=C3)C=C4C(C(C=C(O)C=C5)=C5N4)=C21)=O"
+    )
+    assert (  # matches line 44 in file
+        provider[17052].system.ligand.name
+        == "CN(N=C1)C=C1C(C=C2)=NN3C2=NN=C3[C@@H](C)C4=CC=C(N=CC=C5)C5=C4"
+    )
+    assert isinstance(provider.systems[0].protein, KLIFSKinase)
+    assert provider.systems[0].protein.toolkit == "MDAnalysis"


### PR DESCRIPTION
## Description
This PR adds proper handling of toolkits and protein_types for ChEMBL and PKIS2 dataset providers, i.e. toolkit parameters in the from_source method. Also, the protein_type can now be specified in form of a string which improves interplay with experiments binding affinity.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] add toolkit parameter
  - [x] switch to protein_type via string
  - [x] update tests 
  - [x] tests pass

## Other
 - [x] extend docstrings for handling protein modeling

## Status
- [x] Ready to go