### PR TITLE
merge chembl provider tests

### DIFF
--- a/kinoml/tests/datasets/test_chembl.py
+++ b/kinoml/tests/datasets/test_chembl.py
@@ -3,8 +3,8 @@ Test kinoml.datasets.core
 """
 
 
-def test_chembl_protein_openeye():
-    from kinoml.core.proteins import Protein
+def test_chembl():
+    from kinoml.core.proteins import Protein, KLIFSKinase
     from kinoml.datasets.chembl import ChEMBLDatasetProvider
 
     # we will use a small subset with 100 entries only, for speed
@@ -19,12 +19,6 @@ def test_chembl_protein_openeye():
     assert isinstance(chembl.systems[0].protein, Protein)
     assert chembl.systems[0].protein.toolkit == "OpenEye"
 
-
-def test_chembl_klifskinase_mdanalysis():
-    from kinoml.core.proteins import KLIFSKinase
-    from kinoml.datasets.chembl import ChEMBLDatasetProvider
-
-    # we will use a small subset with 100 entries only, for speed
     chembl = ChEMBLDatasetProvider.from_source(
         "https://github.com/openkinome/kinodata/releases/download/v0.3/activities-chembl29_v0.3.zip",
         uniprot_ids=["P00533"],


### PR DESCRIPTION
## Description
The CI was failing sometimes due to the simultaneous execution of two tests of the ChEML dataset provider, which had problems with downloading and caching the zipped dataset when using multiprocessing. This PR merges both tests, so they are executed sequentially.

## Status
- [x] Ready to go