### PR TITLE
DOCS: Using micromamba actions instead of miniconda.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,41 +19,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: "Setup micromamba"
+        uses: mamba-org/setup-micromamba@v2
         with:
-          installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
-          python-version: "3.7"
-          activate-environment: test
-          channel-priority: true
           environment-file: devtools/conda-envs/docs_env.yaml
-          auto-activate-base: false
-          use-mamba: true
+          environment-name: kinoml-docs-env
+          cache-environment: true
+          cache-downloads: true
+          create-args: >-
+            python=3.10
+          init-shell: bash
 
-      - name: Additional info about the build
+      - name: "Additional info about the build"
         shell: bash
         run: |
           uname -a
           df -h
           ulimit -a
 
-      - name: Environment Information
+      - name: "Environment Information"
         shell: bash -l {0}
         run: |
           conda info --all
           conda list
 
-      - name: Build docs
+      - name: "Build docs"
         shell: bash -l {0}
         run: |
           cd docs
           make clean
           SPHINXOPTS="-T --keep-going" make html
 
-      - name: Deploy
+      - name: "Deploy"
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   # core
   #- sphinx~=2.4.0
   - sphinx
-  - jinja2<=3.0.3
+  - jinja2
   - nbsphinx
   - nbsphinx-link
   - sphinx-notfound-page

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -26,7 +26,6 @@ dependencies:
   - sphinx-autobuild
   - pip:
       # core
-      - sphinx-version-warning
+      #- sphinx-version-warning
       - sphinxemoji
       - sphinx-last-updated-by-git
-

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -24,8 +24,8 @@ dependencies:
   - sphinx-material
   # local building
   - sphinx-autobuild
-  - pip:
+  #- pip:
       # core
       #- sphinx-version-warning
-      - sphinxemoji
-      - sphinx-last-updated-by-git
+      #- sphinxemoji
+      #- sphinx-last-updated-by-git

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -15,7 +15,7 @@ dependencies:
   - sphinx-notfound-page
   - sphinx-prompt
   - sphinx-copybutton
-  - sphinx-autoapi>=3<4
+  - sphinx-autoapi>=3,<4
   - myst-parser
   - sphinxcontrib-httpdomain
   - linkify-it-py

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -19,7 +19,7 @@ dependencies:
   - myst-parser
   - sphinxcontrib-httpdomain
   - linkify-it-py
-  - sphinx-panels
+  #- sphinx-panels
   # themes
   - sphinx-material
   # local building

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -15,7 +15,7 @@ dependencies:
   - sphinx-notfound-page
   - sphinx-prompt
   - sphinx-copybutton
-  - sphinx-autoapi
+  - sphinx-autoapi>=3<4
   - myst-parser
   - sphinxcontrib-httpdomain
   - linkify-it-py

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -8,6 +8,7 @@ dependencies:
   - ipython
   # core
   #- sphinx~=2.4.0
+  - docutils=0.20  # Support for nbsphinx_link 1.3.0
   - sphinx
   - jinja2
   - nbsphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ autoapi_root = "api"
 autoapi_add_toctree_entry = False
 autoapi_ignore = [
     "*migrations*",
-    "_version*",
+    "*_version*",
     "*tests*",
     "*/data/*",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ extensions = [
     "nbsphinx",
     "nbsphinx_link",
     # "sphinx_last_updated_by_git",
-    "sphinx_panels",
+    # "sphinx_panels",
     "IPython.sphinxext.ipython_console_highlighting",
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.todo",
     "sphinx.ext.napoleon",
-    "sphinxemoji.sphinxemoji",
+    # "sphinxemoji.sphinxemoji",
     "sphinx-prompt",
     "sphinx_copybutton",
     # "notfound.extension",
@@ -43,7 +43,7 @@ extensions = [
     "autoapi.extension",
     "nbsphinx",
     "nbsphinx_link",
-    "sphinx_last_updated_by_git",
+    # "sphinx_last_updated_by_git",
     "sphinx_panels",
     "IPython.sphinxext.ipython_console_highlighting",
 ]


### PR DESCRIPTION
## Description
This changes are for using `micromamba` environment and actions workflow, instead of the `miniconda` one, for the documentation generation and deployment. 