### PR TITLE
Update author in GH Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,4 +59,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
This workflow keeps adding a commit on my name every day, which is not representative of my work here, so let's assign this to GH Actions for fairness.

cc @raquellrios @AndreaVolkamer 